### PR TITLE
Always grab the current token

### DIFF
--- a/rover/src/main/java/io/rover/ObjectSerializer.java
+++ b/rover/src/main/java/io/rover/ObjectSerializer.java
@@ -219,7 +219,7 @@ public class ObjectSerializer implements JsonApiPayloadProvider.JsonApiObjectSer
             jsonObject.put("model", device.getModel());
             jsonObject.put("time-zone", device.getTimeZone());
             jsonObject.put("bluetooth-enabled", device.getBluetoothEnabled(mApplicationContext));
-            jsonObject.put("token", device.getGcmToken(mApplicationContext));
+            jsonObject.put("token", device.getGcmToken());
             jsonObject.put("aid", device.getAdvertisingIdentifier());
             jsonObject.put("ad-tracking", device.getAdTrackingEnabled());
             jsonObject.put("location-monitoring-enabled", device.getLocationMonitoringEnabled());

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -545,10 +545,8 @@ public class Rover implements EventSubmitTask.Callback {
         @Override
         public void onTokenRefresh() {
             String token = FirebaseInstanceId.getInstance().getToken();
-            Device.setGcmToken(token, mSharedInstance.mApplicationContext);
-
-            Log.i("TOKEN", token);
-
+            Log.i(TAG, "Refreshed token: " + token);
+            Device.getInstance().setGcmToken(token);
             Event event = new DeviceUpdateEvent(new Date());
             mSharedInstance.sendEvent(event);
         }

--- a/rover/src/main/java/io/rover/model/Device.java
+++ b/rover/src/main/java/io/rover/model/Device.java
@@ -8,6 +8,8 @@ import android.os.Build;
 import android.support.v4.app.NotificationManagerCompat;
 import android.telephony.TelephonyManager;
 
+import com.google.firebase.iid.FirebaseInstanceId;
+
 import java.util.Locale;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -79,24 +81,18 @@ public class Device {
         return false;
     }
 
-    public String getGcmToken(Context context) {
+    public String getGcmToken() {
         if (mGcmToken != null) {
             return mGcmToken;
         }
 
-        SharedPreferences sharedData = context.getSharedPreferences(SHARED_DEVICE, 0);
-        mGcmToken = sharedData.getString("GCM_TOKEN", null);
+        mGcmToken = FirebaseInstanceId.getInstance().getToken();
 
         return mGcmToken;
     }
 
-    public static void setGcmToken(String token, Context context) {
-        Device.getInstance().mGcmToken = token;
-
-        SharedPreferences sharedData = context.getSharedPreferences(SHARED_DEVICE, 0);
-        SharedPreferences.Editor editor = sharedData.edit();
-        editor.putString("GCM_TOKEN", token);
-        editor.apply();
+    public void setGcmToken(String token) {
+       mGcmToken = token;
     }
 
     public String getAdvertisingIdentifier() {


### PR DESCRIPTION
Do not rely only on token refresh events to grab the current token. If someone were to have fcm already installed the token refresh event will never be fired. The `mGcmToken` variable is now just an in memory cache of the current token instead of saving it to disk