### PR TITLE
Remote notification helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Using the [Rover Messages App](https://app.rover.io/messages/) you can create me
 
 ### Notifications
 
+**IMPORTANT** Rover reserves the key `_rover` in the notification's data payload. Please ensure all notifications not originating from the Rover Platform do not specifiy this key.
+
 In order to have notification and messages working, Rover needs your FCM server key. Use [this guide](https://github.com/RoverPlatform/rover-android/wiki/FCM-Setup) to upload your configure Rover with your FCM setup.
 
 If you like fine-grained control over notifications, you must register a [NotificationProvider](https://github.com/RoverPlatform/rover-android/blob/master/rover/src/main/java/io/rover/NotificationProvider.java) during initialization.

--- a/README.md
+++ b/README.md
@@ -113,8 +113,6 @@ Using the [Rover Messages App](https://app.rover.io/messages/) you can create me
 
 ### Notifications
 
-**IMPORTANT** Rover reserves the key `_rover` in the notification's data payload. Please ensure all notifications not originating from the Rover Platform do not specifiy this key.
-
 In order to have notification and messages working, Rover needs your FCM server key. Use [this guide](https://github.com/RoverPlatform/rover-android/wiki/FCM-Setup) to upload your configure Rover with your FCM setup.
 
 If you like fine-grained control over notifications, you must register a [NotificationProvider](https://github.com/RoverPlatform/rover-android/blob/master/rover/src/main/java/io/rover/NotificationProvider.java) during initialization.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,30 @@ If you like fine-grained control over notifications, you must register a [Notifi
 
 Check the [Notification Provider](https://github.com/RoverPlatform/rover-android/blob/master/rover/src/main/java/io/rover/NotificationProvider.java) file for more documentation on methods to customize behavior.
 
+#### Custom FirebaseMessagingService
+
+If your app is already currently using FCM and implements the `FirebaseMessagingService`, helper methods have been provided to handle Rover notifications. The following example demonstrates these methods
+
+```java
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+import io.rover.Rover;
+
+public class MyFirebaseMessagingService extends FirebaseMessagingService {
+    @Override
+    public void onMessageReceived(RemoteMessage remoteMessage) {
+        if (Rover.isRoverMessage(remoteMessage)) {
+            Rover.handleRemoteMessage(remoteMessage);
+            return;
+        }
+
+        // ...
+        // Parse the message as your own
+    }
+}
+```
+
 ### Inbox
 
 Most applications provide means for users to recall messages. You can use the `onMessageReceived(Message message)` callback on a [`MessageDeliveryObserver`](https://github.com/RoverPlatform/rover-android/blob/master/rover/src/main/java/io/rover/RoverObserver.java) to map and add Rover messages to your application's inbox as they are delivered. You may also rely solely on Rover for a simple implementation of such inbox if your application doesn't already have one:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you like fine-grained control over notifications, you must register a [Notifi
 
 Check the [Notification Provider](https://github.com/RoverPlatform/rover-android/blob/master/rover/src/main/java/io/rover/NotificationProvider.java) file for more documentation on methods to customize behavior.
 
-#### Custom FirebaseMessagingService
+### Custom FirebaseMessagingService
 
 If your app is already currently using FCM and implements the `FirebaseMessagingService`, helper methods have been provided to handle Rover notifications. The following example demonstrates these methods
 
@@ -183,7 +183,7 @@ startActivity(intent);
 ```
 
 
-### Customer Identity
+## Customer Identity
 
 By default the Rover platform will assign a unique identifier to each customer who installs your application. However you may choose to assign your own identifiers. This is particularly useful for mapping data from the Rover Analytics app or if a customer is using your application on multiple platforms. To accomodate this Rover saves customer info to device storage so that it persists across sessions. The following snippet demonstrates assigning your own customer identifier:
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
 }
 ```
 
+### Default Back Button Behaviour
+
+If you do not provide a [Notification Provider](https://github.com/RoverPlatform/rover-android/blob/master/rover/src/main/java/io/rover/NotificationProvider.java) to Rover the default back behaviour is to use the parent activity provided in your AndroidManifest file. This is only the case when a message will launch a LandingPage or an Experience. The following example demonstrates that when the back button is pressed after launching an Experience from a notification the MainActivity will run. 
+
+```xml
+...
+ <activity android:name="io.rover.ExperienceActivity"
+    android:parentActivityName=".MainActivity">
+    <meta-data
+        android:name="android.support.PARENT_ACTIVITY"
+        android:value=".MainActivity"/>
+</activity>
+...
+```
+
 ### Inbox
 
 Most applications provide means for users to recall messages. You can use the `onMessageReceived(Message message)` callback on a [`MessageDeliveryObserver`](https://github.com/RoverPlatform/rover-android/blob/master/rover/src/main/java/io/rover/RoverObserver.java) to map and add Rover messages to your application's inbox as they are delivered. You may also rely solely on Rover for a simple implementation of such inbox if your application doesn't already have one:

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -475,10 +475,8 @@ public class Rover implements EventSubmitTask.Callback {
             }
 
             String jsonString = data.get("message");
-
             if (jsonString == null) {
                 return null;
-
             }
 
             try {
@@ -502,6 +500,7 @@ public class Rover implements EventSubmitTask.Callback {
     }
 
     public static PendingIntent getPendingIntentFromRoverMessage(io.rover.model.Message message) {
+        
         if (message == null) {
             return null;
         }

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -574,12 +574,10 @@ public class Rover implements EventSubmitTask.Callback {
             smallIcon = mSharedInstance.mNotificationProvider.getSmallIconForNotification(message);
             largeIcon = mSharedInstance.mNotificationProvider.getLargeIconForNotification(message);
             sound = mSharedInstance.mNotificationProvider.getSoundForNotification(message);
-        } else {
-            pendingIntent = getPendingIntentFromRoverMessage(message);
         }
 
         if (pendingIntent == null) {
-            Log.d(TAG, "No Intent specified");
+            pendingIntent = getPendingIntentFromRoverMessage(message);
         }
 
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context)

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -501,7 +501,7 @@ public class Rover implements EventSubmitTask.Callback {
         return  null;
     }
 
-    public static PendingIntent getIntentFromRoverMessage(io.rover.model.Message message) {
+    public static PendingIntent getPendingIntentFromRoverMessage(io.rover.model.Message message) {
         if (message == null) {
             return null;
         }
@@ -576,7 +576,7 @@ public class Rover implements EventSubmitTask.Callback {
             largeIcon = mSharedInstance.mNotificationProvider.getLargeIconForNotification(message);
             sound = mSharedInstance.mNotificationProvider.getSoundForNotification(message);
         } else {
-            pendingIntent = getIntentFromRoverMessage(message);
+            pendingIntent = getPendingIntentFromRoverMessage(message);
         }
 
         if (pendingIntent == null) {


### PR DESCRIPTION
We aren’t guaranteed that we will be the only service listening for FCM messages. If another service is listening for remote messages our service will never be called. This provides helper methods + cleanup to allow the developer to easily check if remote messages can be handled by Rover and to tell Rover to handle the remote message.