### PR TITLE
Send device update event when traits change

### DIFF
--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -153,6 +153,8 @@ public class Rover implements EventSubmitTask.Callback {
                 customer.setTraits(traits.getCustomTraits());
 
             customer.save(mSharedInstance.mApplicationContext);
+            Event event = new DeviceUpdateEvent(new Date());
+            mSharedInstance.sendEvent(event);
         }
     }
 
@@ -160,6 +162,8 @@ public class Rover implements EventSubmitTask.Callback {
         Customer customer = getCustomer();
         if (customer != null) {
             customer.clear(mSharedInstance.mApplicationContext);
+            Event event = new DeviceUpdateEvent(new Date());
+            mSharedInstance.sendEvent(event);
         }
     }
 


### PR DESCRIPTION
Do not wait for an event in the future to update the new traits of the customer. These traits are time sensitive
Closes #77 