### PR TITLE
Fix button insets

### DIFF
--- a/rover/src/main/java/io/rover/ui/ButtonBlockView.java
+++ b/rover/src/main/java/io/rover/ui/ButtonBlockView.java
@@ -46,7 +46,6 @@ public class ButtonBlockView extends TextBlockView {
         mTitleAlignments = new HashMap<>();
         mTitleAlignments.put(State.Normal, new Alignment(Alignment.Horizontal.Center, Alignment.Vertical.Middle));
         mTitleOffsets = new HashMap<>();
-        mTitleOffsets.put(State.Normal, Offset.ZeroOffset);
         mTitleTypefaces = new HashMap<>();
         mTitleTypefaces.put(State.Normal, (new Font(12, 400).getTypeface()));
         mBackgroundColors = new HashMap<>();


### PR DESCRIPTION
Do not initialize a block view to have a zero offset for the title. Title offset overrides the inset property
Closes #85 