### PR TITLE
Make getPendingIntent public

### DIFF
--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -636,7 +636,7 @@ public class Rover implements EventSubmitTask.Callback {
     }
 
 
-    private static PendingIntent getPendingIntentFromRoverMessage(io.rover.model.Message message, MessageInteractionService.Source source) {
+    public static PendingIntent getPendingIntentFromRoverMessage(io.rover.model.Message message, MessageInteractionService.Source source) {
         if (message == null) {
             return null;
         }


### PR DESCRIPTION
Allow the developer to set the source of the pending intent. This is usefull when the developer implements their own FCMListener

Closes #104 