### PR TITLE
Properly tile images

### DIFF
--- a/rover/src/main/java/io/rover/ui/BackgroundImageHelper.java
+++ b/rover/src/main/java/io/rover/ui/BackgroundImageHelper.java
@@ -33,11 +33,7 @@ public class BackgroundImageHelper {
                 break;
             }
             case Tile: {
-                imageView.setScaleType(ImageView.ScaleType.MATRIX);
-                Matrix matrix = new Matrix();
-                float scaleFactor = imageView.getContext().getResources().getDisplayMetrics().density / backgroundScale;
-                matrix.setScale(scaleFactor, scaleFactor);
-                imageView.setImageMatrix(matrix);
+                imageView.setScaleType(ImageView.ScaleType.FIT_XY);
                 BitmapDrawable bitmapDrawable = new BitmapDrawable(resources, bitmap);
                 bitmapDrawable.setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT);
                 imageView.setImageDrawable(bitmapDrawable);


### PR DESCRIPTION
Set the image view scale type to fit XY. This will then in turn force the drawable to expand to fit the image view. With the bitmap set to tile the bitmap drawable is now responsible for tiling to fit the X and Y of the image view

Closes #122 