### PR TITLE
Use MD5 hash as cached file names

### DIFF
--- a/rover/src/main/java/io/rover/ui/AssetDownloader.java
+++ b/rover/src/main/java/io/rover/ui/AssetDownloader.java
@@ -79,7 +79,7 @@ public class AssetDownloader extends AsyncTask<String, Void, Bitmap> {
             }
 
         } catch (Exception e) {
-            Log.e("AssetDownloader", "Error downloading asset: " + e.getMessage());
+            Log.e(TAG, "Error downloading asset: " + e.getMessage());
             return null;
         }
     }

--- a/rover/src/main/java/io/rover/ui/AssetDownloader.java
+++ b/rover/src/main/java/io/rover/ui/AssetDownloader.java
@@ -12,12 +12,15 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLEncoder;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 /**
  * Created by Rover Labs Inc on 2016-07-07.
  */
 public class AssetDownloader extends AsyncTask<String, Void, Bitmap> {
+
+    private static final String TAG = "AssetDownloader";
 
     public interface AssetDownloaderListener {
         void onAssetDownloadSuccess(Bitmap bitmap);
@@ -40,14 +43,17 @@ public class AssetDownloader extends AsyncTask<String, Void, Bitmap> {
         }
 
         try {
-            // Check disk cache first
 
+            String cacheKey = getCachekey(urlString);
 
-            String encodedUrl = URLEncoder.encode(urlString, "UTF-8");
-            File file = new File(mCacheDir, encodedUrl);
+            if (cacheKey != null) {
+                // Check disk cache first
 
-            if (file.exists()) {
-                return BitmapFactory.decodeFile(file.getAbsolutePath());
+                File file = new File(mCacheDir, cacheKey);
+
+                if (file.exists()) {
+                    return BitmapFactory.decodeFile(file.getAbsolutePath());
+                }
             }
 
             // Download Asset
@@ -58,26 +64,76 @@ public class AssetDownloader extends AsyncTask<String, Void, Bitmap> {
             connection.connect();
             InputStream input = connection.getInputStream();
 
-            // Write to cache
-            OutputStream outputStream = new FileOutputStream(file);
-
-            byte[] buffer = new byte[1024];
-            int bytesRead;
-            while ((bytesRead = input.read(buffer)) != -1) {
-                outputStream.write(buffer, 0, bytesRead);
+            if (cacheKey != null) {
+                File file = new File(mCacheDir, cacheKey);
+                saveFileToCache(input, file);
+                connection.disconnect();
+                input.close();
+                return BitmapFactory.decodeFile(file.getAbsolutePath());
+            } else {
+                // we are unable to save file to disk so we will just convert the input stream to a Bitmap
+                Bitmap bitmap = BitmapFactory.decodeStream(input);
+                input.close();
+                connection.disconnect();
+                return bitmap;
             }
-            input.close();
-            outputStream.flush();
-            outputStream.close();
 
-            connection.disconnect();
-
-            return BitmapFactory.decodeFile(file.getAbsolutePath());
-        } catch (IOException e) {
+        } catch (Exception e) {
             Log.e("AssetDownloader", "Error downloading asset: " + e.getMessage());
             return null;
         }
     }
+
+    private String getCachekey(String url) {
+
+        if (url == null) {
+            return null;
+        }
+
+        MessageDigest digester = null;
+
+        try {
+            digester = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+
+        byte [] messageDigest = digester.digest(url.getBytes());
+
+        StringBuffer hexString = new StringBuffer();
+
+        for (int i = 0; i < messageDigest.length; i++) {
+            String hex = Integer.toHexString(0xFF & messageDigest[i]);
+
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+
+            hexString.append(hex);
+        }
+
+        return hexString.toString();
+    }
+
+    private void saveFileToCache(InputStream input, File file) {
+        // Write to cache
+        OutputStream outputStream = null;
+        try {
+            outputStream = new FileOutputStream(file);
+            byte[] buffer = new byte[1024];
+            int bytesRead;
+
+            while ((bytesRead = input.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, bytesRead);
+            }
+
+            outputStream.flush();
+            outputStream.close();
+        } catch (IOException e) {
+            Log.w(TAG, "Unable to cache file: " + file.getPath(), e);
+        }
+    }
+
 
     @Override
     protected void onPostExecute(Bitmap bitmap) {


### PR DESCRIPTION
Encoding the entire url as a file will blow the 255 character limit androids filesystem has. To counter this we instead take the MD5 hash of the url and use that as the file name.


Closes #124 