### PR TITLE
guard against destroyed experience activity

### DIFF
--- a/rover/src/main/java/io/rover/ExperienceActivity.java
+++ b/rover/src/main/java/io/rover/ExperienceActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.annotation.MainThread;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
@@ -110,7 +111,14 @@ public class ExperienceActivity extends AppCompatActivity implements ScreenFragm
         }
     }
 
+    @MainThread
     public void setExperience(Experience experience) {
+
+        if (isDestroyed()) {
+            Log.d(TAG, "Activity is destroyed skipping setExperience");
+            return;
+        }
+
         mExperience = experience;
 
         Rover.submitEvent(new ExperienceLaunchEvent(mExperience, mSessionId, new Date()));


### PR DESCRIPTION
When a user presses the back button before the async task completes an exception is thrown. This is because the activity is destroyed and can no longer be updated.

Closes #129 