### PR TITLE
guard against empty data urls

### DIFF
--- a/rover/src/main/java/io/rover/ExperienceActivity.java
+++ b/rover/src/main/java/io/rover/ExperienceActivity.java
@@ -236,8 +236,10 @@ public class ExperienceActivity extends AppCompatActivity implements ScreenFragm
                 break;
             }
             default: {
-                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(action.getUrl()));
-                startActivity(intent);
+                if (action.getUrl() != null && !action.getUrl().isEmpty()) {
+                    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(action.getUrl()));
+                    startActivity(intent);
+                }
                 break;
             }
         }


### PR DESCRIPTION
Guard against blocks which don’t have an associated data url


Closes #130 