### PR TITLE
Only pass screen id to ScreenFragment

### DIFF
--- a/rover/src/main/java/io/rover/ExperienceActivity.java
+++ b/rover/src/main/java/io/rover/ExperienceActivity.java
@@ -137,12 +137,20 @@ public class ExperienceActivity extends AppCompatActivity implements ScreenFragm
         presentNextScreen(homeScreen);
     }
 
+    @Nullable
+    public Screen getScreen(String screenId) {
+        if (mExperience == null) {
+            return null;
+        }
+        return mExperience.getScreen(screenId);
+    }
+
     public void presentNextScreen(Screen screen) {
         if (screen == null) {
             return;
         }
 
-        Fragment screenFragment = ScreenFragment.newInstance(screen);
+        Fragment screenFragment = ScreenFragment.newInstance(screen.getId());
 
         presentNextScreen(screenFragment, screen, new ExperienceScreenAnimation());
     }

--- a/rover/src/main/java/io/rover/ui/ScreenFragment.java
+++ b/rover/src/main/java/io/rover/ui/ScreenFragment.java
@@ -30,6 +30,8 @@ import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import java.util.ArrayList;
+
+import io.rover.ExperienceActivity;
 import io.rover.model.Block;
 import io.rover.model.Image;
 import io.rover.model.Row;
@@ -41,10 +43,13 @@ public class ScreenFragment extends Fragment implements RowsAdapter.BlockListene
         void onBlockClick(Fragment screenFragment, Screen screen, Block block);
     }
 
+    private static final String BUNDLE_SCREEN_ID = "BUNDLE_SCREEN_ID";
+    private static final String BUNDLE_SCREEN = "BUNDLE_SCREEN";
+
     public static String TAG = "SCREEN_FRAGMENT";
-    public static String ARG_SCREEN = "SCREEN_KEY";
     private static String RECYCLER_STATE_KEY = "RECYCLER_STATE_KEY";
 
+    private String mScreenId;
     private Screen mScreen;
     private RowsAdapter mAdapter;
     private ImageView mBackgroundView;
@@ -55,10 +60,20 @@ public class ScreenFragment extends Fragment implements RowsAdapter.BlockListene
     public static ScreenFragment newInstance(Screen screen) {
         ScreenFragment fragment = new ScreenFragment();
         Bundle args = new Bundle();
-        args.putParcelable(ARG_SCREEN, screen);
+        args.putParcelable(BUNDLE_SCREEN, screen);
         fragment.setArguments(args);
         return fragment;
     }
+
+    public static ScreenFragment newInstance(String screenId) {
+        ScreenFragment fragment = new ScreenFragment();
+        Bundle args = new Bundle();
+        args.putString(BUNDLE_SCREEN_ID, screenId);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -66,7 +81,10 @@ public class ScreenFragment extends Fragment implements RowsAdapter.BlockListene
         setHasOptionsMenu(true);
 
         if (getArguments() != null) {
-            mScreen = getArguments().getParcelable(ARG_SCREEN);
+            // Support for Landing Pages
+            mScreen = getArguments().getParcelable(BUNDLE_SCREEN);
+
+            mScreenId = getArguments().getString(BUNDLE_SCREEN_ID);
         }
     }
 
@@ -121,6 +139,10 @@ public class ScreenFragment extends Fragment implements RowsAdapter.BlockListene
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
+
+        if (getActivity() instanceof ExperienceActivity) {
+            mScreen = ((ExperienceActivity) getActivity()).getScreen(mScreenId);
+        }
 
         if (mScreen != null) {
             setScreen(mScreen);


### PR DESCRIPTION
Don't pass the entire screen as a parcelable to the Screen Fragment. This causes Android to throw a TransactionToLarge if the individual screen is too large. Instead pass in the screen id to the fragment. The fragment now asks the ExperienceActivity for the screen by screen id. This puts the responsibility of managing experience data in the ExperienceActivity

For backwards compatibility we still allow for the screen to be passed in as a parcelable. An example of which case are LandingPages.

Closes #131 