### PR TITLE
Add campaign ids to Experiences

### DIFF
--- a/rover/src/main/java/io/rover/ExperienceActivity.java
+++ b/rover/src/main/java/io/rover/ExperienceActivity.java
@@ -21,6 +21,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Date;
 import java.util.UUID;
 
@@ -43,14 +44,16 @@ import io.rover.ui.ScreenFragment;
  * Created by Rover Labs Inc on 2016-08-15.
  */
 public class ExperienceActivity extends AppCompatActivity implements ScreenFragment.OnBlockListener {
-    
-    private static String TAG = "ExperienceActivity";
 
+    public static final String CAMPAIGN_ID_QUERY_PARAMETER = "campaign-id";
+
+    private static String TAG = "ExperienceActivity";
 
     private RelativeLayout mLayout;
     private FetchExperienceTask mFetchTask;
     private Experience mExperience;
     private String mSessionId;
+    private String mCampaignId;
     private boolean mHasPresentedFirstScreen = false;
 
 
@@ -77,6 +80,12 @@ public class ExperienceActivity extends AppCompatActivity implements ScreenFragm
                 mFetchTask = new FetchExperienceTask();
                 mFetchTask.execute(experienceId);
             }
+
+            try {
+                mCampaignId = data.getQueryParameter(CAMPAIGN_ID_QUERY_PARAMETER);
+            } catch (NullPointerException|UnsupportedOperationException ignored) {
+                mCampaignId = null;
+            }
         }
 
         mSessionId = UUID.randomUUID().toString();
@@ -98,7 +107,7 @@ public class ExperienceActivity extends AppCompatActivity implements ScreenFragm
         }
 
         if (isFinishing() && mExperience != null) {
-            Rover.submitEvent(new ExperienceDismissEvent(mExperience, mSessionId, new Date()));
+            Rover.submitEvent(new ExperienceDismissEvent(mExperience, mSessionId, mCampaignId, new Date()));
 
             for (RoverObserver observer : Rover.mSharedInstance.mObservers) {
                 if (observer instanceof RoverObserver.ExperienceObserver) {
@@ -121,7 +130,7 @@ public class ExperienceActivity extends AppCompatActivity implements ScreenFragm
 
         mExperience = experience;
 
-        Rover.submitEvent(new ExperienceLaunchEvent(mExperience, mSessionId, new Date()));
+        Rover.submitEvent(new ExperienceLaunchEvent(mExperience, mSessionId, mCampaignId, new Date()));
 
         for (RoverObserver observer : Rover.mSharedInstance.mObservers) {
             if (observer instanceof RoverObserver.ExperienceObserver) {
@@ -221,7 +230,7 @@ public class ExperienceActivity extends AppCompatActivity implements ScreenFragm
             return;
         }
 
-        Rover.submitEvent(new BlockPressEvent(block, screen, mExperience, mSessionId, new Date()));
+        Rover.submitEvent(new BlockPressEvent(block, screen, mExperience, mSessionId, mCampaignId, new Date()));
 
         for (RoverObserver observer : Rover.mSharedInstance.mObservers) {
             if (observer instanceof RoverObserver.ExperienceObserver) {
@@ -286,7 +295,7 @@ public class ExperienceActivity extends AppCompatActivity implements ScreenFragm
     }
 
     private void trackScreenView(Fragment screenFragment, Screen screen, Screen fromScreen, Block fromBlock) {
-        Rover.submitEvent(new ScreenViewEvent(screen, mExperience, fromScreen, fromBlock, mSessionId, new Date()));
+        Rover.submitEvent(new ScreenViewEvent(screen, mExperience, fromScreen, fromBlock, mSessionId, mCampaignId, new Date()));
 
         for (RoverObserver observer : Rover.mSharedInstance.mObservers) {
             if (observer instanceof RoverObserver.ExperienceObserver) {

--- a/rover/src/main/java/io/rover/ObjectSerializer.java
+++ b/rover/src/main/java/io/rover/ObjectSerializer.java
@@ -138,6 +138,8 @@ public class ObjectSerializer implements JsonApiPayloadProvider.JsonApiObjectSer
                 jsonObject.put("experience-id", expEvent.getExperience().getId());
                 jsonObject.put("version-id", expEvent.getExperience().getVersion());
                 jsonObject.put("experience-session-id", expEvent.getSessionId());
+                jsonObject.put("campaign-id", expEvent.getCampaignId());
+
             } else if (event instanceof ExperienceDismissEvent) {
                 ExperienceDismissEvent expEvent = (ExperienceDismissEvent)event;
 
@@ -146,6 +148,8 @@ public class ObjectSerializer implements JsonApiPayloadProvider.JsonApiObjectSer
                 jsonObject.put("experience-id", expEvent.getExperience().getId());
                 jsonObject.put("version-id", expEvent.getExperience().getVersion());
                 jsonObject.put("experience-session-id", expEvent.getSessionId());
+                jsonObject.put("campaign-id", expEvent.getCampaignId());
+
             } else if (event instanceof ScreenViewEvent) {
                 ScreenViewEvent expEvent = (ScreenViewEvent)event;
 
@@ -154,6 +158,8 @@ public class ObjectSerializer implements JsonApiPayloadProvider.JsonApiObjectSer
                 jsonObject.put("experience-id", expEvent.getExperience().getId());
                 jsonObject.put("version-id", expEvent.getExperience().getVersion());
                 jsonObject.put("experience-session-id", expEvent.getSessionId());
+                jsonObject.put("campaign-id", expEvent.getCampaignId());
+
                 if (expEvent.getScreen() != null) {
                     jsonObject.put("screen-id", expEvent.getScreen().getId());
                 }
@@ -170,6 +176,8 @@ public class ObjectSerializer implements JsonApiPayloadProvider.JsonApiObjectSer
                 jsonObject.put("action", "block-clicked");
                 jsonObject.put("version-id", expEvent.getExperience().getVersion());
                 jsonObject.put("experience-session-id", expEvent.getSessionId());
+                jsonObject.put("campaign-id", expEvent.getCampaignId());
+
                 if (expEvent.getBlock() != null) {
                     jsonObject.put("block-id", expEvent.getBlock().getId());
                 }

--- a/rover/src/main/java/io/rover/model/BlockPressEvent.java
+++ b/rover/src/main/java/io/rover/model/BlockPressEvent.java
@@ -10,13 +10,15 @@ public class BlockPressEvent extends Event {
     private Screen mScreen;
     private Experience mExperience;
     private String mSessionId;
+    private String mCampaignId;
 
-    public BlockPressEvent(Block block, Screen screen, Experience experience, String session, Date date) {
+    public BlockPressEvent(Block block, Screen screen, Experience experience, String session, String campaignId, Date date) {
         mBlock = block;
         mScreen = screen;
         mExperience = experience;
         mDate = date;
         mSessionId = session;
+        mCampaignId = campaignId;
     }
 
     public Block getBlock() {
@@ -32,4 +34,8 @@ public class BlockPressEvent extends Event {
     }
 
     public String getSessionId() { return mSessionId; }
+
+    public String getCampaignId() {
+        return mCampaignId;
+    }
 }

--- a/rover/src/main/java/io/rover/model/ExperienceDismissEvent.java
+++ b/rover/src/main/java/io/rover/model/ExperienceDismissEvent.java
@@ -8,14 +8,20 @@ import java.util.Date;
 public class ExperienceDismissEvent extends Event {
     private Experience mExperience;
     private String mSessionId;
+    private String mCampaignId;
 
-    public ExperienceDismissEvent(Experience experience, String sessionId, Date date) {
+    public ExperienceDismissEvent(Experience experience, String sessionId, String campaignId, Date date) {
         mDate = date;
         mExperience = experience;
         mSessionId = sessionId;
+        mCampaignId = campaignId;
     }
 
     public Experience getExperience() { return mExperience; }
 
     public String getSessionId() { return mSessionId; }
+
+    public String getCampaignId() {
+        return mCampaignId;
+    }
 }

--- a/rover/src/main/java/io/rover/model/ExperienceLaunchEvent.java
+++ b/rover/src/main/java/io/rover/model/ExperienceLaunchEvent.java
@@ -8,11 +8,13 @@ import java.util.Date;
 public class ExperienceLaunchEvent extends Event {
     private Experience mExperience;
     private String mSessionId;
+    private String mCampaignId;
 
-    public ExperienceLaunchEvent(Experience experience, String session, Date date) {
+    public ExperienceLaunchEvent(Experience experience, String session, String campaignId, Date date) {
         mDate = date;
         mExperience = experience;
         mSessionId = session;
+        mCampaignId = campaignId;
     }
 
     public Experience getExperience() {
@@ -21,5 +23,9 @@ public class ExperienceLaunchEvent extends Event {
 
     public String getSessionId() {
         return mSessionId;
+    }
+
+    public String getCampaignId() {
+        return mCampaignId;
     }
 }

--- a/rover/src/main/java/io/rover/model/ScreenViewEvent.java
+++ b/rover/src/main/java/io/rover/model/ScreenViewEvent.java
@@ -11,14 +11,16 @@ public class ScreenViewEvent extends Event {
     private Screen mFromScreen;
     private Block mFromBlock;
     private String mSessionId;
+    private String mCampaignId;
 
-    public ScreenViewEvent(Screen screen, Experience experience, Screen fromScreen, Block fromBlock, String session, Date date) {
+    public ScreenViewEvent(Screen screen, Experience experience, Screen fromScreen, Block fromBlock, String session, String campaignId, Date date) {
         mScreen = screen;
         mExperience = experience;
         mFromScreen = fromScreen;
         mFromBlock = fromBlock;
         mDate = date;
         mSessionId = session;
+        mCampaignId = campaignId;
     }
 
     public Screen getScreen() {
@@ -38,4 +40,8 @@ public class ScreenViewEvent extends Event {
     }
 
     public String getSessionId() { return mSessionId; }
+
+    public String getCampaignId() {
+        return mCampaignId;
+    }
 }


### PR DESCRIPTION
Allow the developer to pass in their own custom campaign-id into the rover Experience. Any event generated within the Experience will now be associated with the campaign-id