### PR TITLE
Loosen firebase and play-services dependencies

### DIFF
--- a/rover/build.gradle
+++ b/rover/build.gradle
@@ -47,10 +47,10 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.4.0'
 
-    compile 'com.google.android.gms:play-services-location:[9.2.1,10.0.0['
-    compile 'com.google.android.gms:play-services-nearby:[9.2.1,10.0.0['
+    compile 'com.google.android.gms:play-services-location:[9.2.1,)'
+    compile 'com.google.android.gms:play-services-nearby:[9.2.1,)'
 
-    compile 'com.google.firebase:firebase-messaging:[9.2.1,10.0.0['
+    compile 'com.google.firebase:firebase-messaging:[9.2.1,)'
 
     compile 'com.android.support:recyclerview-v7:23.4.0'
 }


### PR DESCRIPTION
Loosen firbase and play-services dependencies to allow for apps with higher versions to compile with Rover.  This is under the assumption that there are no breaking changes between major versions. Rover would be resposible for testing and letting the client know if the version they require works