### PR TITLE
Use a callback to grab the current gcm token

### DIFF
--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -93,6 +93,7 @@ public class Rover implements EventSubmitTask.Callback {
     private PendingIntent mAppLaunchPendingIntent;
     private ExecutorService mEventExecutorService = Executors.newSingleThreadExecutor();
     protected ArrayList<RoverObserver> mObservers = new ArrayList<>();
+    protected OnRequestDeviceToken mDeviceTokenRequest;
     private NotificationProvider mNotificationProvider;
 
     private boolean mGimbalMode;
@@ -116,6 +117,10 @@ public class Rover implements EventSubmitTask.Callback {
     public interface OnInboxReloadListener {
         void onSuccess(List<io.rover.model.Message> messages);
         void onFailure();
+    }
+
+    public interface OnRequestDeviceToken {
+        String getToken() throws Exception;
     }
 
 
@@ -414,6 +419,13 @@ public class Rover implements EventSubmitTask.Callback {
         mSharedInstance.mObservers.remove(observer);
     }
 
+    public static void setOnRequestDeviceToken(OnRequestDeviceToken deviceTokenRequest) {
+        mSharedInstance.mDeviceTokenRequest = deviceTokenRequest;
+    }
+
+    public static OnRequestDeviceToken getOnRequestDeviceToken() {
+        return mSharedInstance.mDeviceTokenRequest;
+    }
 
     public static void reloadInbox(final OnInboxReloadListener listener) {
         if (!isInitialized()) {

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -93,7 +93,7 @@ public class Rover implements EventSubmitTask.Callback {
     private PendingIntent mAppLaunchPendingIntent;
     private ExecutorService mEventExecutorService = Executors.newSingleThreadExecutor();
     protected ArrayList<RoverObserver> mObservers = new ArrayList<>();
-    protected OnRequestDeviceToken mDeviceTokenRequest;
+    protected OnRequestDeviceTokenListener mOnRequestDeviceTokenListener;
     private NotificationProvider mNotificationProvider;
 
     private boolean mGimbalMode;
@@ -119,8 +119,8 @@ public class Rover implements EventSubmitTask.Callback {
         void onFailure();
     }
 
-    public interface OnRequestDeviceToken {
-        String getToken() throws Exception;
+    public interface OnRequestDeviceTokenListener {
+        String onRequestDeviceToken() throws Exception;
     }
 
 
@@ -419,12 +419,12 @@ public class Rover implements EventSubmitTask.Callback {
         mSharedInstance.mObservers.remove(observer);
     }
 
-    public static void setOnRequestDeviceToken(OnRequestDeviceToken deviceTokenRequest) {
-        mSharedInstance.mDeviceTokenRequest = deviceTokenRequest;
+    public static void setOnRequestDeviceTokenListener(OnRequestDeviceTokenListener deviceTokenRequestListener) {
+        mSharedInstance.mOnRequestDeviceTokenListener = deviceTokenRequestListener;
     }
 
-    public static OnRequestDeviceToken getOnRequestDeviceToken() {
-        return mSharedInstance.mDeviceTokenRequest;
+    public static OnRequestDeviceTokenListener getOnRequestDeviceTokenListener() {
+        return mSharedInstance.mOnRequestDeviceTokenListener;
     }
 
     public static void reloadInbox(final OnInboxReloadListener listener) {

--- a/rover/src/main/java/io/rover/model/Device.java
+++ b/rover/src/main/java/io/rover/model/Device.java
@@ -114,14 +114,14 @@ public class Device {
             return mGcmToken;
         }
 
-        Rover.OnRequestDeviceToken deviceTokenRequest = Rover.getOnRequestDeviceToken();
+        Rover.OnRequestDeviceTokenListener deviceTokenRequestListener = Rover.getOnRequestDeviceTokenListener();
 
         // Check if the user has provided a callback to provide us a token
-        if (deviceTokenRequest != null) {
+        if (deviceTokenRequestListener != null) {
             try {
-                mGcmToken = deviceTokenRequest.getToken();
+                mGcmToken = deviceTokenRequestListener.onRequestDeviceToken();
             } catch (Exception e) {
-                Log.w(TAG, "Exception was thrown while trying to retrieve device token in OnRequestDeviceToken");
+                Log.w(TAG, "Exception was thrown while trying to retrieve device token in OnRequestDeviceTokenListener");
             }
         } else {
             // The default is to grab the token from Firebase

--- a/rover/src/main/java/io/rover/model/Device.java
+++ b/rover/src/main/java/io/rover/model/Device.java
@@ -15,6 +15,8 @@ import java.util.MissingResourceException;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import io.rover.Rover;
+
 /**
  * Created by Roverlabs Inc. on 2016-03-31.
  */
@@ -112,10 +114,22 @@ public class Device {
             return mGcmToken;
         }
 
-        try {
-            mGcmToken = FirebaseInstanceId.getInstance().getToken();
-        } catch (Exception e) {
-            Log.w(TAG, "Unable to get device's push token");
+        Rover.OnRequestDeviceToken deviceTokenRequest = Rover.getOnRequestDeviceToken();
+
+        // Check if the user has provided a callback to provide us a token
+        if (deviceTokenRequest != null) {
+            try {
+                mGcmToken = deviceTokenRequest.getToken();
+            } catch (Exception e) {
+                Log.w(TAG, "Exception was thrown while trying to retrieve device token in OnRequestDeviceToken");
+            }
+        } else {
+            // The default is to grab the token from Firebase
+            try {
+                mGcmToken = FirebaseInstanceId.getInstance().getToken();
+            } catch (Exception e) {
+                Log.w(TAG, "Unable to get device's push token");
+            }
         }
 
         return mGcmToken;


### PR DESCRIPTION
To support both firbase and gcm at the same time, use a callback that the developer implements to retrieve the current token for push. Rover ensures that this function is called inside a background thread only.