### PR TITLE
Support for expandable notifications.

### DIFF
--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -1054,6 +1054,7 @@ public class Rover implements EventSubmitTask.Callback {
                 .setContentTitle(message.getTitle())
                 .setContentText(message.getText())
                 .setContentIntent(contentIntent)
+                .setStyle(new NotificationCompat.BigTextStyle())
                 .setDeleteIntent(deleteIntent);
 
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16714/31619659-319c108c-b263-11e7-8b82-35e70c652333.png)
is now 
![image](https://user-images.githubusercontent.com/16714/31619673-39d66e64-b263-11e7-875e-842def1aa475.png)

Can be long-pressed to pull down, as per standard Android big notifications.