### PR TITLE
Bump to latest Build SDK, support lib, and Play Services version and better explain & handle Google dependencies when client app build SDK does not match

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,19 @@
 ## Requirements
   - Android Studio 2.1.2 or higher
   - Min Android SDK 18
-  - GooglePlayServices 9.0.2 on device
-  - Firebase account
+  - Firebase account that is [configured for cloud messaging](https://github.com/RoverPlatform/rover-android/wiki/FCM-Setup)
+  - Firebase [integrated into your app](https://firebase.google.com/docs/android/setup).
+  - Three Google Play Services libraries [integrated into your app](https://developers.google.com/android/guides/setup), namely:
+    - play-services-location
+    - play-services-nearby
+    - firebase-messaging
   
 ## Installing the Library
 
-Before continuing with the installation of the Rover SDK, please make sure you have setup you project and Android app in the [Firebase Console](https://console.firebase.google.com/).
+Before continuing with the installation of the Rover SDK, please make sure you
+have setup you project and Android app in the [Firebase
+Console](https://console.firebase.google.com/) as mentioned above in the
+Requirements.
 
 ### JCenter
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
   - Min Android SDK 18
   - Firebase account that is [configured for cloud messaging](https://github.com/RoverPlatform/rover-android/wiki/FCM-Setup)
   - Firebase [integrated into your app](https://firebase.google.com/docs/android/setup).
-  - Three Google Play Services libraries [integrated into your app](https://developers.google.com/android/guides/setup), namely:
+  - Two Google Play Services libraries [integrated into your app](https://developers.google.com/android/guides/setup), namely:
     - play-services-location
     - play-services-nearby
-    - firebase-messaging
   
 ## Installing the Library
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ compile 'io.rover.library:rover:1.15.5'
 
 // COMING SOON
 
+### Dealing with Support Library Conflicts
+
+The Rover SDK depends on a few of the Android support libraries.  Because of
+this, if your app is building against an older Android build SDK than 26, you
+may need to add an exclusion for `com.android.support` when importing the Rover SDK:
+
+```
+compile 'io.rover.library:rover:1.15.5' {
+    exclude group: 'com.android.support'
+}
+```
+
+See the example app's [app/build.gradle](app/build.gradle) for more details.
+
 ## Intializing the SDK
 
 The Rover SDK **MUST** be initialized inside the Application base class `onCreate` method. If your Android application doesn't already have an Application base class, follow [these](https://developer.android.com/reference/android/app/Application.html) instructions to create one.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,29 +23,31 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
 
-    // The Rover SDK requires two components of the Android support library.  There are a few
-    // extra steps if your app is building against an older Android build SDK.  This example app
-    // builds against Android SDK 23 instead of SDK 26 used by the Rover SDK to help illustrate
-    // how to deal with this.
-    // The Rover SDK is able to work with the concomitant versions of Google's
-    // Support libraries intended for versions of the Android SDK
-    // older than 26, but because it is not possible to express that effectively to Gradle's
+    // The Rover SDK requires two components of the Android support library.  Because of this,
+    // there are a few extra steps if your app is building against an older Android build SDK.
+    // This example app builds against Android SDK 23 instead of SDK 26 used by the Rover SDK to
+    // help demonstrate how to deal with this.
+    // Android Support Library major versions must match the build SDK being used for your app.
+    // The Rover SDK is indeed able to work with any of the support libraries matching the build
+    // SDK used by your app, but because it is not possible to express that effectively to Gradle's
     // dependency resolver, it is necessary to override the transitive requests for these
-    // dependencies from the Rover SDK with the ones appropriate to your Build SDK.  If this is not
-    // done, the request for the newer Support libraries will propagate transitively from the Rover
-    // SDK into your app and fail your build by mismatching with your Android build SDK.
+    // dependencies coming from the Rover SDK with the ones appropriate to your Build SDK.  If this
+    // is not done, the request for the newer Support libraries will propagate transitively from
+    // the Rover SDK into your app and fail your build by mismatching with your Android build SDK.
+    //
     // Note that this method is not necessary in the case where the reverse is true: if your app is
     // specifying newer versions of the Build SDK/Support Libraries, then Gradle's default
     // prefer-latest conflict resolution behaviour will be appropriate.
     compile(project(':rover')) {
+        // and here is the exclusion itself as explained above:
         exclude group: 'com.android.support'
     }
     // and then import the versions of support-v4, appcompat-v7, and recyclerview-v7 appropriate
-    // to your choice of Build SDK.
+    // to your choice of your Android build SDK (ie., their major versions match your build SDK, given
+    // here as 23).
     compile 'com.android.support:support-v4:23.4.0'
     compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.android.support:recyclerview-v7:23.4.0'
-
 
     // Your app must import the desired Google Play Services itself.
     compile 'com.google.android.gms:play-services-location:11.0.4'
@@ -53,12 +55,5 @@ dependencies {
     compile 'com.google.firebase:firebase-messaging:11.0.4'
     compile 'com.android.support:design:23.4.0'
 }
-
-//configurations.all {
-//    resolutionStrategy {
-//        failOnVersionConflict()
-//    }
-//}
-
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.example.rover"
@@ -22,12 +22,43 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile project(':rover')
-    compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'com.android.support:design:23.2.1'
-    compile 'com.android.support:support-v4:23.2.1'
-    compile 'com.android.support:recyclerview-v7:23.2.1'
 
+    // The Rover SDK requires two components of the Android support library.  There are a few
+    // extra steps if your app is building against an older Android build SDK.  This example app
+    // builds against Android SDK 23 instead of SDK 26 used by the Rover SDK to help illustrate
+    // how to deal with this.
+    // The Rover SDK is able to work with the concomitant versions of Google's
+    // Support libraries intended for versions of the Android SDK
+    // older than 26, but because it is not possible to express that effectively to Gradle's
+    // dependency resolver, it is necessary to override the transitive requests for these
+    // dependencies from the Rover SDK with the ones appropriate to your Build SDK.  If this is not
+    // done, the request for the newer Support libraries will propagate transitively from the Rover
+    // SDK into your app and fail your build by mismatching with your Android build SDK.
+    // Note that this method is not necessary in the case where the reverse is true: if your app is
+    // specifying newer versions of the Build SDK/Support Libraries, then Gradle's default
+    // prefer-latest conflict resolution behaviour will be appropriate.
+    compile(project(':rover')) {
+        exclude group: 'com.android.support'
+    }
+    // and then import the versions of support-v4, appcompat-v7, and recyclerview-v7 appropriate
+    // to your choice of Build SDK.
+    compile 'com.android.support:support-v4:23.4.0'
+    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:recyclerview-v7:23.4.0'
+
+
+    // Your app must import the desired Google Play Services itself.
+    compile 'com.google.android.gms:play-services-location:11.0.4'
+    compile 'com.google.android.gms:play-services-nearby:11.0.4'
+    compile 'com.google.firebase:firebase-messaging:11.0.4'
+    compile 'com.android.support:design:23.4.0'
 }
+
+//configurations.all {
+//    resolutionStrategy {
+//        failOnVersionConflict()
+//    }
+//}
+
 
 apply plugin: 'com.google.gms.google-services'

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.google.gms:google-services:3.1.0'
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
@@ -22,6 +22,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 01 13:25:40 EDT 2016
+#Wed Sep 20 13:16:31 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/rover/build.gradle
+++ b/rover/build.gradle
@@ -42,7 +42,6 @@ android {
     }
 }
 
-
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
@@ -61,15 +60,7 @@ dependencies {
     provided 'com.google.android.gms:play-services-location:11.0.4'
     provided 'com.google.android.gms:play-services-nearby:11.0.4'
     provided 'com.google.firebase:firebase-messaging:11.0.4'
-
-
 }
-
-//configurations.all {
-//    resolutionStrategy {
-//        failOnVersionConflict()
-//    }
-//}
 
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'

--- a/rover/build.gradle
+++ b/rover/build.gradle
@@ -25,8 +25,8 @@ ext {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 26
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 18
@@ -42,18 +42,34 @@ android {
     }
 }
 
+
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
 
-    compile 'com.google.android.gms:play-services-location:[9.2.1,)'
-    compile 'com.google.android.gms:play-services-nearby:[9.2.1,)'
+    // We import here two support library modules appropriate to the Build SDK used for the Rover
+    // SDK itself.  However, user apps that wish to build against older Build SDKs (supported but not
+    // necessarily recommended), they will have to use a `{ exclude group: "com.android.support" }`
+    // directive
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:recyclerview-v7:26.1.0'
 
-    compile 'com.google.firebase:firebase-messaging:[9.2.1,)'
+    // When users of the Rover SDK wish to use the Push and Location services, they must import
+    // them themselves.  This is necessary because the 'com.google.gms.google-services' Gradle
+    // plugin that must be used in apps that consume the Play Services feature assumes the
+    // responsibility of importing the appropriate Play Services dependencies.
+    provided 'com.google.android.gms:play-services-location:11.0.4'
+    provided 'com.google.android.gms:play-services-nearby:11.0.4'
+    provided 'com.google.firebase:firebase-messaging:11.0.4'
 
-    compile 'com.android.support:recyclerview-v7:23.4.0'
+
 }
+
+//configurations.all {
+//    resolutionStrategy {
+//        failOnVersionConflict()
+//    }
+//}
 
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'


### PR DESCRIPTION
This patch keeps the example app at build SDK 23, but bumps the Rover SDK itself up to build SDK 26, and so furnishes the user with instructions with how to add the needed support library override to their gradle build if they want to stay back on an older build SDK.

Before this, I was seeing nasty class loader exceptions as below getting logged when trying to register for cloud messaging (and pushes with the example app naturally not working).  Bumping the play services library fixed it, but that also meant bumping support lib/build SDK.  This turned out to be good; forced me to think through what the developer experience would be for users with a build SDK setting on their project that does not match the one on the SDK (a highly likely scenario).

```
10-18 12:59:49.211 2728-2728/? I/art: Rejecting re-init on previously-failed class java.lang.Class<com.google.android.gms.measurement.internal.UserAttributeParcel>: java.lang.NoClassDefFoundError: Failed resolution of: Lcom/google/android/gms/common/internal/safeparcel/AbstractSafeParcelable;
10-18 12:59:49.211 2728-2728/? I/art:     at java.lang.Class java.lang.Class.classForName!(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:-2)
10-18 12:59:49.211 2728-2728/? I/art:     at java.lang.Class java.lang.Class.forName(java.lang.String, boolean, java.lang.ClassLoader) (Class.java:400)
10-18 12:59:49.211 2728-2728/? I/art:     at java.lang.Class java.lang.Class.forName(java.lang.String) (Class.java:326)
10-18 12:59:49.211 2728-2728/? I/art:     at void com.google.firebase.FirebaseApp.zza(java.lang.Class, java.lang.Object, java.lang.Iterable) ((null):-1)
10-18 12:59:49.211 2728-2728/? I/art:     at com.google.firebase.FirebaseApp com.google.firebase.FirebaseApp.initializeApp(android.content.Context, com.google.firebase.FirebaseOptions, java.lang.String) ((null):-1)
10-18 12:59:49.211 2728-2728/? I/art:     at com.google.firebase.FirebaseApp com.google.firebase.FirebaseApp.initializeApp(android.content.Context, com.google.firebase.FirebaseOptions) ((null):-1)
10-18 12:59:49.211 2728-2728/? I/art:     at com.google.firebase.FirebaseApp com.google.firebase.FirebaseApp.initializeApp(android.content.Context) ((null):-1)
10-18 12:59:49.211 2728-2728/? I/art:     at boolean com.google.firebase.provider.FirebaseInitProvider.onCreate() ((null):-1)
10-18 12:59:49.211 2728-2728/? I/art:     at void android.content.ContentProvider.attachInfo(android.content.Context, android.content.pm.ProviderInfo, boolean) (ContentProvider.java:1758)
10-18 12:59:49.211 2728-2728/? I/art:     at void android.content.ContentProvider.attachInfo(android.content.Context, android.content.pm.ProviderInfo) (ContentProvider.java:1733)
10-18 12:59:49.211 2728-2728/? I/art:     at void com.google.firebase.provider.FirebaseInitProvider.attachInfo(android.content.Context, android.content.pm.ProviderInfo) ((null):-1)
10-18 12:59:49.211 2728-2728/? I/art:     at android.app.IActivityManager$ContentProviderHolder android.app.ActivityThread.installProvider(android.content.Context, android.app.IActivityManager$ContentProviderHolder, android.content.pm.ProviderInfo, boolean, boolean, boolean) (ActivityThread.java:6326)
10-18 12:59:49.211 2728-2728/? I/art:     at void android.app.ActivityThread.installContentProviders(android.content.Context, java.util.List) (ActivityThread.java:5918)
10-18 12:59:49.211 2728-2728/? I/art:     at void android.app.ActivityThread.handleBindApplication(android.app.ActivityThread$AppBindData) (ActivityThread.java:5857)
10-18 12:59:49.211 2728-2728/? I/art:     at void android.app.ActivityThread.-wrap3(android.app.ActivityThread, android.app.ActivityThread$AppBindData) (ActivityThread.java:-1)
10-18 12:59:49.211 2728-2728/? I/art:     at void android.app.ActivityThread$H.handleMessage(android.os.Message) (ActivityThread.java:1699)
10-18 12:59:49.211 2728-2728/? I/art:     at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:102)
10-18 12:59:49.211 2728-2728/? I/art:     at void android.os.Looper.loop() (Looper.java:154)
10-18 12:59:49.211 2728-2728/? I/art:     at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:6682)
10-18 12:59:49.211 2728-2728/? I/art:     at java.lang.Object java.lang.reflect.Method.invoke!(java.lang.Object, java.lang.Object[]) (Method.java:-2)
10-18 12:59:49.211 2728-2728/? I/art:     at void com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run() (ZygoteInit.java:1520)
10-18 12:59:49.211 2728-2728/? I/art:     at void com.android.internal.os.ZygoteInit.main(java.lang.String[]) (ZygoteInit.java:1410)
```