### PR TITLE
v1.16.0: Oreo (API 27) support

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
@@ -27,17 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -6,6 +6,7 @@
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/rover/rover.iml" filepath="$PROJECT_DIR$/rover/rover.iml" />
       <module fileurl="file://$PROJECT_DIR$/rover-android.iml" filepath="$PROJECT_DIR$/rover-android.iml" />
+      <module fileurl="file://$PROJECT_DIR$/rover-android-legacy.iml" filepath="$PROJECT_DIR$/rover-android-legacy.iml" />
     </modules>
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Before continuing with the installation of the Rover SDK, please make sure you h
 The easiest way to get Rover into your Android project is to use the [JCenter](https://bintray.com/bintray/jcenter) Maven repository. Just add the following line to the `dependencies` section of your module's `build.gradle` file:
 
 ```
-compile 'io.rover.library:rover:1.15.6'
+compile 'io.rover.library:rover:1.16.0'
 ```
 
 ### Manual Installation

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 27
 
     defaultConfig {
         applicationId "com.example.rover"
         minSdkVersion 18
-        targetSdkVersion 23
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -20,13 +19,13 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile project(':rover')
-    compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'com.android.support:design:23.2.1'
-    compile 'com.android.support:support-v4:23.2.1'
-    compile 'com.android.support:recyclerview-v7:23.2.1'
+    implementation project(':rover')
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:support-v4:27.1.1'
+    implementation 'com.android.support:recyclerview-v7:27.1.1'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.google.gms:google-services:3.2.0'
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
@@ -22,6 +23,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 01 13:25:40 EDT 2016
+#Wed Apr 18 10:34:01 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/rover/build.gradle
+++ b/rover/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/RoverPlatform/rover-android'
     gitUrl = 'https://github.com/RoverPlatform/rover-android.git'
 
-    libraryVersion = '1.15.6'
+    libraryVersion = '1.16.0'
 
     developerId = 'ata-n'
     developerName = 'Ata N'
@@ -25,12 +25,11 @@ ext {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 27
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 23
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -43,16 +42,16 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:support-v4:27.1.1'
+    implementation 'com.android.support:recyclerview-v7:27.1.1'
+    api 'com.google.android.gms:play-services-location:15.0.0'
+    api 'com.google.android.gms:play-services-nearby:15.0.0'
+    api 'com.google.firebase:firebase-core:15.0.0'
+    api 'com.google.firebase:firebase-messaging:15.0.0'
 
-    compile 'com.google.android.gms:play-services-location:[9.2.1,)'
-    compile 'com.google.android.gms:play-services-nearby:[9.2.1,)'
-
-    compile 'com.google.firebase:firebase-messaging:[9.2.1,)'
-
-    compile 'com.android.support:recyclerview-v7:23.4.0'
 }
 
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'

--- a/rover/src/main/AndroidManifest.xml
+++ b/rover/src/main/AndroidManifest.xml
@@ -8,39 +8,30 @@
     <!-- uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/ -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
 
-    <!--<permission-->
-        <!--android:name="${applicationId}.permission.C2D_MESSAGE"-->
-        <!--android:protectionLevel="signature" />-->
-
-    <!--<uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />-->
-
     <application
         android:allowBackup="true"
         android:supportsRtl="true">
 
-        <!-- Services -->
+        <!-- Intent Receivers for location information -->
+        <receiver
+            android:name=".Rover$NearbyMessageService" />
+        <receiver
+            android:name=".Rover$LocationUpdateService" />
+        <receiver
+            android:name=".Rover$GeofenceTransitionService" />
 
-        <service
-            android:name=".Rover$NearbyMessageService"
-            android:exported="false" />
-        <service
-            android:name=".Rover$LocationUpdateService"
-            android:exported="false" />
-        <service
-            android:name=".Rover$GeofenceTransitionService"
-            android:exported="false" />
-
+        <!-- All Rover notifications launch this service when tapped, which then in turn launches the appropriate component. -->
         <service
             android:name=".MessageInteractionService"
             android:exported="false" />
 
+        <!-- Services that receive the Firebase registration information -->
         <service
             android:name=".Rover$RoverFirebaseInstanceIdService">
             <intent-filter>
                 <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
             </intent-filter>
         </service>
-
         <service
             android:name=".Rover$RoverFirebaseMessagingService">
             <intent-filter>

--- a/rover/src/main/AndroidManifest.xml
+++ b/rover/src/main/AndroidManifest.xml
@@ -14,11 +14,11 @@
 
         <!-- Intent Receivers for location information -->
         <receiver
-            android:name=".Rover$NearbyMessageService" />
+            android:name=".Rover$NearbyMessageReceiver" />
         <receiver
-            android:name=".Rover$LocationUpdateService" />
+            android:name=".Rover$LocationUpdateReceiver" />
         <receiver
-            android:name=".Rover$GeofenceTransitionService" />
+            android:name=".Rover$GeofenceTransitionReceiver" />
 
         <!-- All Rover notifications launch this service when tapped, which then in turn launches the appropriate component. -->
         <service

--- a/rover/src/main/java/io/rover/EventSubmitTask.java
+++ b/rover/src/main/java/io/rover/EventSubmitTask.java
@@ -134,8 +134,8 @@ public class EventSubmitTask implements Runnable, JsonApiResponseHandler.JsonApi
 
         if (geofenceRegions.size() > 0) {
             mCallback.onReceivedGeofences(geofenceRegions);
+        } else {
+            Log.i(TAG, "No geofences in received device state, so not monitoring for them.");
         }
-
-
     }
 }

--- a/rover/src/main/java/io/rover/EventSubmitTask.java
+++ b/rover/src/main/java/io/rover/EventSubmitTask.java
@@ -135,7 +135,7 @@ public class EventSubmitTask implements Runnable, JsonApiResponseHandler.JsonApi
         if (geofenceRegions.size() > 0) {
             mCallback.onReceivedGeofences(geofenceRegions);
         } else {
-            Log.i(TAG, "No geofences in received device state, so not monitoring for them.");
+            Log.i(TAG, "No geofences in event submission result, so not changing currently monitored geofences.");
         }
     }
 }

--- a/rover/src/main/java/io/rover/MessageInteractionService.java
+++ b/rover/src/main/java/io/rover/MessageInteractionService.java
@@ -50,7 +50,6 @@ public class MessageInteractionService extends IntentService {
             } catch (PendingIntent.CanceledException e) {
                 e.printStackTrace();
             }
-
         }
     }
 }

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -297,8 +297,8 @@ public class Rover implements EventSubmitTask.Callback {
         }
 
         final LocationRequest locationRequest = new LocationRequest()
-                .setInterval(1)
-                .setFastestInterval(1)
+                .setInterval(900000)
+                .setFastestInterval(900000)
                 .setSmallestDisplacement(0)
                 .setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
 

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -3,6 +3,7 @@ package io.rover;
 import android.Manifest;
 import android.app.Application;
 import android.app.IntentService;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
@@ -12,12 +13,14 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.net.http.HttpResponseCache;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
@@ -165,6 +168,19 @@ public class Rover implements EventSubmitTask.Callback {
             Log.i(TAG, "HTTP response cache installation failed:" + e);
         }
 
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel notificationChannel = new NotificationChannel(
+                CHANNEL_ID,
+                "Default",
+                NotificationManager.IMPORTANCE_DEFAULT
+            );
+
+            notificationChannel.setDescription("Default");
+
+            ((NotificationManager) application.getSystemService(Context.NOTIFICATION_SERVICE)).createNotificationChannel(
+                notificationChannel
+            );
+        }
     }
 
     public static boolean isInitialized() {
@@ -1061,6 +1077,10 @@ public class Rover implements EventSubmitTask.Callback {
                 .setStyle(new NotificationCompat.BigTextStyle())
                 .setDeleteIntent(deleteIntent);
 
+        if(Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
+            builder.setChannelId("rover");
+        }
+
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         manager.notify(message.getId(), Rover.NOTIFICATION_ID, builder.build());
     }
@@ -1160,4 +1180,6 @@ public class Rover implements EventSubmitTask.Callback {
             Rover.handleRemoteMessage(remoteMessage);
         }
     }
+
+    private static String CHANNEL_ID = "rover";
 }

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -78,7 +78,7 @@ import io.rover.util.Util;
  */
 public class Rover implements EventSubmitTask.Callback {
 
-    protected static String VERSION = "1.15.6";
+    protected static String VERSION = "1.16.0";
     protected static Rover mSharedInstance = new Rover();
     protected static int NOTIFICATION_ID = 12345;
 

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -1082,7 +1082,7 @@ public class Rover implements EventSubmitTask.Callback {
                 .setDeleteIntent(deleteIntent);
 
         if(Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
-            builder.setChannelId("rover");
+            builder.setChannelId(CHANNEL_ID);
         }
 
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -373,7 +373,7 @@ public class Rover implements EventSubmitTask.Callback {
                                             @Override
                                             public void onResult(@NonNull Status status) {
                                                 if (status.isSuccess()) {
-                                                    Log.i("Nearby", "Unsubscribed successfuly.");
+                                                    Log.i("Nearby", "Unsubscribed successfully.");
                                                 } else {
                                                     Log.w("Nearby", "Could not unsubscribe");
                                                 }

--- a/rover/src/main/java/io/rover/Rover.java
+++ b/rover/src/main/java/io/rover/Rover.java
@@ -2,7 +2,6 @@ package io.rover;
 
 import android.Manifest;
 import android.app.Application;
-import android.app.IntentService;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -20,7 +19,6 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
@@ -586,7 +584,7 @@ public class Rover implements EventSubmitTask.Callback {
         }
 
         if (mLocationPendingIntent == null) {
-            Intent intent = new Intent(mApplicationContext, LocationUpdateService.class);
+            Intent intent = new Intent(mApplicationContext, LocationUpdateReceiver.class);
             mLocationPendingIntent = PendingIntent.getBroadcast(mApplicationContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
         }
 
@@ -601,7 +599,7 @@ public class Rover implements EventSubmitTask.Callback {
         }
 
         if (mGeofencePendingIntent == null) {
-            Intent intent = new Intent(mApplicationContext, GeofenceTransitionService.class);
+            Intent intent = new Intent(mApplicationContext, GeofenceTransitionReceiver.class);
             mGeofencePendingIntent = PendingIntent.getBroadcast(mApplicationContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
         }
         return mGeofencePendingIntent;
@@ -615,7 +613,7 @@ public class Rover implements EventSubmitTask.Callback {
         }
 
         if (mNearbyMessagesPendingIntent == null) {
-            Intent intent = new Intent(mApplicationContext, NearbyMessageService.class);
+            Intent intent = new Intent(mApplicationContext, NearbyMessageReceiver.class);
             mNearbyMessagesPendingIntent = PendingIntent.getBroadcast(mApplicationContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
         }
         return mNearbyMessagesPendingIntent;
@@ -1101,7 +1099,7 @@ public class Rover implements EventSubmitTask.Callback {
      * Broadcast Receivers (actually they receive unicast messages from the Google location services)
      */
 
-    static public class LocationUpdateService extends BroadcastReceiver {
+    static public class LocationUpdateReceiver extends BroadcastReceiver {
 
         @Override
         public void onReceive(Context context, Intent intent) {
@@ -1113,7 +1111,7 @@ public class Rover implements EventSubmitTask.Callback {
         }
     }
 
-    static public class GeofenceTransitionService extends BroadcastReceiver {
+    static public class GeofenceTransitionReceiver extends BroadcastReceiver {
         @Override
         public void onReceive(Context context, Intent intent) {
             GeofencingEvent geofencingEvent = GeofencingEvent.fromIntent(intent);
@@ -1139,7 +1137,7 @@ public class Rover implements EventSubmitTask.Callback {
         }
     }
 
-    static public class NearbyMessageService extends BroadcastReceiver {
+    static public class NearbyMessageReceiver extends BroadcastReceiver {
         @Override
         public void onReceive(Context context, Intent intent) {
             Nearby.Messages.handleIntent(intent, new MessageListener() {


### PR DESCRIPTION
A few changes:

* switching all three IntentServices that received background location information to be BroadcastReceivers instead.
* full bump of Android SDK, build toolchain, and Google dependencies.  Target SDK set at 27.
* Not worrying about users targeting older versions of the Android SDK or Google dependencies, since upcoming Play Store policies will mean that doing so is no longer optional.
* Improving location-related log messages to be more clear, and also present.
