### PR TITLE
v2.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ block.
 ```groovy
 dependencies {
     // ...
-    implementation "io.rover:core:2.1.3"
-    implementation "io.rover:notifications:2.1.3"
-    implementation "io.rover:experiences:2.1.3"
-    implementation "io.rover:location:2.1.3"
-    implementation "io.rover:debug:2.1.3"
+    implementation "io.rover:core:2.1.4"
+    implementation "io.rover:notifications:2.1.4"
+    implementation "io.rover:experiences:2.1.4"
+    implementation "io.rover:location:2.1.4"
+    implementation "io.rover:debug:2.1.4"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     // all of the modules of the SDK will use this version number.
-    ext.rover_sdk_version = '2.1.3'
+    ext.rover_sdk_version = '2.1.4'
     ext.rover_sdk_version_code = 3
 
     ext.kotlin_version = '1.2.51'

--- a/core/src/main/kotlin/io/rover/core/data/graphql/GraphQlApiService.kt
+++ b/core/src/main/kotlin/io/rover/core/data/graphql/GraphQlApiService.kt
@@ -33,7 +33,7 @@ class GraphQlApiService(
     private fun urlRequest(mutation: Boolean, queryParams: Map<String, String>): HttpRequest {
         val uri = Uri.parse(endpoint.toString())
         val builder = uri.buildUpon()
-        queryParams.forEach { k, v -> builder.appendQueryParameter(k, v) }
+        queryParams.forEach { (k, v) -> builder.appendQueryParameter(k, v) }
 
         return HttpRequest(
             URL(builder.toString()),

--- a/core/src/main/kotlin/io/rover/core/platform/DateFormatting.kt
+++ b/core/src/main/kotlin/io/rover/core/platform/DateFormatting.kt
@@ -19,13 +19,32 @@ class DateFormatting : DateFormattingInterface {
         timeZone = TimeZone.getTimeZone("UTC")
     }
 
-    private fun format8601WithTimeZone() = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US)
+    private val format8601WithTimeZone = if(
+            Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP
+    ) SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US) else
+        // on legacy Android use the RFC 822 format, and below for outgoing values we'll transform
+        // it to 8601.
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
     override fun dateAsIso8601(date: Date, localTime: Boolean): String =
-        if (localTime) format8601WithTimeZone().format(date) else format8601().format(date)
+        if (localTime) {
+            if(Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
+                // new shit
+                format8601WithTimeZone.format(date)
+            } else {
+                // On legacy Android, we are using the RFC 822 (email) vs ISO 8601 date format, and
+                // we use the following regex to transform it to something 8601 compatible≥
+                format8601WithTimeZone.format(
+                    date
+                ).replace(Regex("(\\d\\d)(\\d\\d)$"), "$1:$2")
+            }
+
+        } else format8601().format(date)
 
     override fun iso8601AsDate(iso8601Date: String, localTime: Boolean): Date = try {
-        if (localTime) format8601WithTimeZone().parse(iso8601Date) else format8601().parse(iso8601Date)
+        iso8601Date.replace(Regex("Z$"), "+0000").let { transformed ->
+            if (localTime) format8601WithTimeZone.parse(transformed) else format8601().parse(transformed)
+        }
     } catch (throwable: Throwable) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
             throw JSONException("Could not parse date '$iso8601Date' as ${if (localTime) "local" else "utc"}", throwable)


### PR DESCRIPTION
Resolve two issues on Lollipop.

* Use of `X` format string for date parsing not available at API 19, implement a temporary solution for a date format compatible with our backend in the meantime;
* improper use of forEach Iterable method not available at API 19, replacing it with Kotlin restructuring.