### PR TITLE
Fix: Android Geocoder can throw more than IOException.

### DIFF
--- a/location/src/main/kotlin/io/rover/location/GoogleBackgroundLocationService.kt
+++ b/location/src/main/kotlin/io/rover/location/GoogleBackgroundLocationService.kt
@@ -67,8 +67,8 @@ class GoogleBackgroundLocationService(
                     locationResult.lastLocation.longitude,
                     1
                 ).firstOrNull()
-            } catch (ioException: IOException) {
-                log.w("Unable to use Android Geocoder API: $ioException")
+            } catch (exception: Exception) {
+                log.w("Unable to use Android Geocoder API: $exception")
                 null
             }
 


### PR DESCRIPTION
Resolves #269.