### PR TITLE
Tighten up policy around crash vs warning when Rover is not initialized at various entrypoints to the SDK.

### DIFF
--- a/core/src/main/kotlin/io/rover/core/CoreAssembler.kt
+++ b/core/src/main/kotlin/io/rover/core/CoreAssembler.kt
@@ -420,24 +420,31 @@ data class UrlSchemes(
     val schemes: List<String>
 )
 
+@Deprecated("Use .resolve(EventQueueServiceInterface::class.java)")
 val Rover.eventQueue: EventQueueServiceInterface
     get() = this.resolve(EventQueueServiceInterface::class.java) ?: throw missingDependencyError("EventQueueService")
 
+@Deprecated("Use .resolve(PermissionsNotifierInterface::class.java)")
 val Rover.permissionsNotifier: PermissionsNotifierInterface
     get() = this.resolve(PermissionsNotifierInterface::class.java) ?: throw missingDependencyError("PermissionsNotifier")
 
+@Deprecated("Use .resolve(LinkOpenInterface::class.java)")
 val Rover.linkOpen: LinkOpenInterface
     get() = this.resolve(LinkOpenInterface::class.java) ?: throw missingDependencyError("LinkOpen")
 
+@Deprecated("Use .resolve(AssetService::class.java)")
 val Rover.assetService: AssetService
     get() = this.resolve(AssetService::class.java) ?: throw missingDependencyError("AssetService")
 
+@Deprecated("Use .resolve(Router::class.java)")
 val Rover.router: Router
     get() = this.resolve(Router::class.java) ?: throw missingDependencyError("Router")
 
+@Deprecated("Use .resolve(EmbeddedWebBrowserDisplayInterface::class.java)")
 val Rover.embeddedWebBrowserDisplay
     get() = this.resolve(EmbeddedWebBrowserDisplayInterface::class.java) ?: throw missingDependencyError("EmbeddedWebBrowserDisplayInterface")
 
+@Deprecated("Use .resolve(DeviceIdentificationInterface::class.java)")
 val Rover.deviceIdentification
     get() = this.resolve(DeviceIdentificationInterface::class.java) ?: throw missingDependencyError("DeviceIdentificationInterface")
 

--- a/core/src/main/kotlin/io/rover/core/Rover.kt
+++ b/core/src/main/kotlin/io/rover/core/Rover.kt
@@ -42,9 +42,15 @@ class Rover(
 
         // we have a global singleton of the Rover container.
         @JvmStatic
+        @Deprecated("Please use shared instead.")
         val sharedInstance: Rover
             get() = sharedInstanceBackingField ?: throw RuntimeException("Rover shared instance accessed before calling initialize.\n\n" +
                 "Did you remember to call Rover.initialize() in your Application.onCreate()?")
+
+        @JvmStatic
+        val shared: Rover?
+            get() = sharedInstanceBackingField ?: log.w("Rover shared instance accessed before calling initialize.\n\n" +
+                "Did you remember to call Rover.initialize() in your Application.onCreate()?").let { null }
 
         @JvmStatic
         fun initialize(vararg assemblers: Assembler) {

--- a/core/src/main/kotlin/io/rover/core/container/InjectionContainer.kt
+++ b/core/src/main/kotlin/io/rover/core/container/InjectionContainer.kt
@@ -27,7 +27,7 @@ class InjectionContainer(
         } catch (e: ClassCastException) {
             throw(
                 RuntimeException(errorMessageForFactoryInvocationFailure(type, name), e)
-                )
+            )
         }
     }
 

--- a/debug-app/src/main/java/io/rover/app/debug/DebugMainActivity.kt
+++ b/debug-app/src/main/java/io/rover/app/debug/DebugMainActivity.kt
@@ -10,6 +10,7 @@ import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.view.View
 import io.rover.core.Rover
+import io.rover.core.permissions.PermissionsNotifierInterface
 import io.rover.core.permissionsNotifier
 import io.rover.experiences.ui.containers.ExperienceActivity
 import kotlinx.android.synthetic.main.activity_debug_main.navigation
@@ -80,7 +81,7 @@ class DebugMainActivity : AppCompatActivity() {
             }
         } else {
             // Permission has already been granted
-            Rover.sharedInstance.permissionsNotifier.permissionGranted(
+            Rover.shared!!.resolveSingletonOrFail(PermissionsNotifierInterface::class.java).permissionGranted(
                 Manifest.permission.ACCESS_FINE_LOCATION
             )
         }
@@ -90,7 +91,7 @@ class DebugMainActivity : AppCompatActivity() {
         val perms = permissions.zip(grantResults.toList()).associate { it }
 
         if(perms[Manifest.permission.ACCESS_FINE_LOCATION] == PackageManager.PERMISSION_GRANTED) {
-            Rover.sharedInstance.permissionsNotifier.permissionGranted(
+            Rover.shared!!.resolveSingletonOrFail(PermissionsNotifierInterface::class.java).permissionGranted(
                 Manifest.permission.ACCESS_FINE_LOCATION
             )
         }

--- a/debug-app/src/main/java/io/rover/app/debug/fcm/FirebaseInstanceIdReceiver.kt
+++ b/debug-app/src/main/java/io/rover/app/debug/fcm/FirebaseInstanceIdReceiver.kt
@@ -3,11 +3,11 @@ package io.rover.app.debug.fcm
 import com.google.firebase.iid.FirebaseInstanceId
 import com.google.firebase.iid.FirebaseInstanceIdService
 import io.rover.core.Rover
-import io.rover.notifications.pushReceiver
+import io.rover.notifications.PushReceiverInterface
 
 class FirebaseInstanceIdReceiver : FirebaseInstanceIdService() {
     override fun onTokenRefresh() {
-        Rover.sharedInstance.pushReceiver.onTokenRefresh(
+        Rover.shared?.resolve(PushReceiverInterface::class.java)?.onTokenRefresh(
             FirebaseInstanceId.getInstance().token
         )
     }

--- a/debug-app/src/main/java/io/rover/app/debug/fcm/FirebaseMessageReceiver.kt
+++ b/debug-app/src/main/java/io/rover/app/debug/fcm/FirebaseMessageReceiver.kt
@@ -3,10 +3,12 @@ package io.rover.app.debug.fcm
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import io.rover.core.Rover
-import io.rover.notifications.pushReceiver
+import io.rover.notifications.PushReceiverInterface
 
 class FirebaseMessageReceiver : FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
-        Rover.sharedInstance.pushReceiver.onMessageReceivedData(remoteMessage.data)
+        Rover.shared?.resolve(PushReceiverInterface::class.java)?.onMessageReceivedData(
+            remoteMessage.data
+        )
     }
 }

--- a/debug/src/main/kotlin/io/rover/debug/DebugAssembler.kt
+++ b/debug/src/main/kotlin/io/rover/debug/DebugAssembler.kt
@@ -53,6 +53,7 @@ class DebugAssembler : Assembler {
     }
 }
 
+@Deprecated("Use .resolve(DebugPreferences::class.java)")
 val Rover.debugPreferences: DebugPreferences
     get() = this.resolve(DebugPreferences::class.java) ?: throw missingDependencyError("DebugPreferences")
 

--- a/debug/src/main/kotlin/io/rover/debug/RoverDebugActivity.kt
+++ b/debug/src/main/kotlin/io/rover/debug/RoverDebugActivity.kt
@@ -5,6 +5,9 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.preference.PreferenceFragmentCompat
 import io.rover.core.Rover
+import io.rover.core.eventQueue
+import io.rover.core.logging.log
+import java.lang.RuntimeException
 
 /**
  * This activity displays a list of hidden debug settings for the Rover SDK.
@@ -24,7 +27,6 @@ class RoverDebugActivity : AppCompatActivity() {
     }
 
     class RoverDebugPreferenceFragment : PreferenceFragmentCompat() {
-        private val debugPreferences = Rover.sharedInstance.debugPreferences
 
         override fun onDestroy() {
             super.onDestroy()
@@ -39,6 +41,17 @@ class RoverDebugActivity : AppCompatActivity() {
         }
 
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            val rover = Rover.shared
+            if(rover == null) {
+                log.e("RoverDebugActivity cannot work if Rover is not initialized.  Ignoring.")
+                return
+            }
+            val debugPreferences = rover.resolve(DebugPreferences::class.java)
+            if(debugPreferences == null) {
+                log.e("RoverDebugActivity cannot work if Rover is not initialized, but DebugPreferences is not registered in the Rover container. Ensure DebugAssembler() is in Rover.initialize(). Ignoring.")
+                return
+            }
+
             preferenceManager.sharedPreferencesName = debugPreferences.sharedPreferencesName
             preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(
                 this::sharedPreferenceChangeListener

--- a/experiences/src/main/kotlin/io/rover/experiences/ExperiencesAssembler.kt
+++ b/experiences/src/main/kotlin/io/rover/experiences/ExperiencesAssembler.kt
@@ -514,6 +514,7 @@ class ExperiencesAssembler : Assembler {
     }
 }
 
+@Deprecated("Use .resolve(BarcodeRenderingServiceInterface::class.java)")
 val Rover.barcodeRenderingService: BarcodeRenderingServiceInterface
     get() = this.resolve(BarcodeRenderingServiceInterface::class.java) ?: throw missingDependencyError("BarcodeRenderingServiceInterface")
 

--- a/experiences/src/main/kotlin/io/rover/experiences/ui/TransientLinkLaunchActivity.kt
+++ b/experiences/src/main/kotlin/io/rover/experiences/ui/TransientLinkLaunchActivity.kt
@@ -4,8 +4,8 @@ import android.os.Bundle
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatActivity
 import io.rover.core.Rover
-import io.rover.core.linkOpen
 import io.rover.core.logging.log
+import io.rover.core.routing.LinkOpenInterface
 import java.net.URI
 
 /**
@@ -13,12 +13,19 @@ import java.net.URI
  * point to this activity.
  */
 open class TransientLinkLaunchActivity : AppCompatActivity() {
-    private val linkOpen by lazy {
-        Rover.sharedInstance.linkOpen
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val rover = Rover.shared
+        if(rover == null) {
+            log.e("A deep or universal link mapped to Rover was opened, but Rover is not initialized.  Ignoring.")
+            return
+        }
+        val linkOpen = rover.resolve(LinkOpenInterface::class.java)
+        if(linkOpen == null) {
+            log.e("A deep or universal link mapped to Rover was opened, but LinkOpenInterface is not registered in the Rover container. Ensure ExperiencesAssembler() is in Rover.initialize(). Ignoring.")
+            return
+        }
 
         val uri = URI(intent.data.toString())
 

--- a/experiences/src/main/kotlin/io/rover/experiences/ui/blocks/barcode/ViewBarcode.kt
+++ b/experiences/src/main/kotlin/io/rover/experiences/ui/blocks/barcode/ViewBarcode.kt
@@ -7,7 +7,6 @@ import io.rover.core.Rover
 import io.rover.core.ui.concerns.MeasuredBindableView
 import io.rover.core.ui.concerns.ViewModelBinding
 import io.rover.experiences.BarcodeRenderingServiceInterface
-import io.rover.experiences.barcodeRenderingService
 
 /**
  * Mixin that binds a barcode view model to an [AppCompatImageView] by rendering the barcodes and
@@ -58,5 +57,6 @@ class ViewBarcode(
         }
     }
 
-    private val barcodeRenderingService = Rover.sharedInstance.barcodeRenderingService
+    private val barcodeRenderingService = Rover.shared?.resolve(BarcodeRenderingServiceInterface::class.java) ?:
+        throw RuntimeException("Rover Experience view layer not usable until Rover.initialize has been called (with ExperiencesAssembler included).")
 }

--- a/location/src/main/kotlin/io/rover/location/GoogleBackgroundLocationService.kt
+++ b/location/src/main/kotlin/io/rover/location/GoogleBackgroundLocationService.kt
@@ -144,7 +144,17 @@ class LocationBroadcastReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (LocationResult.hasResult(intent)) {
             val result = LocationResult.extractResult(intent)
-            Rover.sharedInstance.googleBackgroundLocationService.newGoogleLocationResult(result)
+            val rover = Rover.shared
+            if(rover == null) {
+                log.e("Received a location result from Google, but Rover is not initialized.  Ignoring.")
+                return
+            }
+            val backgroundLocationService = rover.resolve(GoogleBackgroundLocationServiceInterface::class.java)
+            if(backgroundLocationService == null) {
+                log.e("Received a location result from Google, but the Rover GoogleBackgroundLocationServiceInterface is missing. Ensure that LocationAssembler is added to Rover.initialize(). Ignoring.")
+                return
+            }
+            else backgroundLocationService.newGoogleLocationResult(result)
         } else {
             log.v("LocationReceiver received an intent, but it lacked a location result. Ignoring. Intent extras were ${intent.extras}")
         }

--- a/location/src/main/kotlin/io/rover/location/GoogleBeaconTrackerService.kt
+++ b/location/src/main/kotlin/io/rover/location/GoogleBeaconTrackerService.kt
@@ -145,7 +145,17 @@ class GoogleBeaconTrackerService(
 
 class BeaconBroadcastReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        Rover.sharedInstance.googleBeaconTrackerService.newGoogleBeaconMessage(
+        val rover = Rover.shared
+        if(rover == null) {
+            log.e("Received a beacon result from Google, but Rover is not initialized.  Ignoring.")
+            return
+        }
+        val beaconTrackerService = rover.resolve(GoogleBeaconTrackerServiceInterface::class.java)
+        if(beaconTrackerService == null) {
+            log.e("Received a beacon result from Google, but GoogleBeaconTrackerServiceInterface is not registered in the Rover container. Ensure LocationAssembler() is in Rover.initialize(). Ignoring.")
+            return
+        }
+        else beaconTrackerService.newGoogleBeaconMessage(
             intent
         )
     }

--- a/location/src/main/kotlin/io/rover/location/GoogleGeofenceService.kt
+++ b/location/src/main/kotlin/io/rover/location/GoogleGeofenceService.kt
@@ -249,7 +249,17 @@ class GoogleGeofenceService(
 
 class GeofenceBroadcastReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        Rover.sharedInstance.googleGeofenceService.newGoogleGeofenceEvent(
+        val rover = Rover.shared
+        if(rover == null) {
+            log.e("Received a geofence result from Google, but Rover is not initialized.  Ignoring.")
+            return
+        }
+        val geofenceService = rover.resolve(GoogleGeofenceServiceInterface::class.java)
+        if(geofenceService == null) {
+            log.e("Received a geofence result from Google, but GoogleGeofenceServiceInterface is not registered in the Rover container. Ensure LocationAssembler() is in Rover.initialize(). Ignoring.")
+            return
+        }
+        geofenceService.newGoogleGeofenceEvent(
             GeofencingEvent.fromIntent(intent)
         )
     }

--- a/location/src/main/kotlin/io/rover/location/LocationAssembler.kt
+++ b/location/src/main/kotlin/io/rover/location/LocationAssembler.kt
@@ -342,12 +342,15 @@ class LocationAssembler(
     }
 }
 
+@Deprecated("Use .resolve(GoogleBackgroundLocationServiceInterface::class.java)")
 val Rover.googleBackgroundLocationService: GoogleBackgroundLocationServiceInterface
     get() = this.resolve(GoogleBackgroundLocationServiceInterface::class.java) ?: throw missingDependencyError("GoogleBackgroundLocationServiceInterface")
 
+@Deprecated("Use .resolve(GoogleBeaconTrackerServiceInterface::class.java)")
 val Rover.googleBeaconTrackerService: GoogleBeaconTrackerServiceInterface
     get() = this.resolve(GoogleBeaconTrackerServiceInterface::class.java) ?: throw missingDependencyError("GoogleBeaconTrackerServiceInterface")
 
+@Deprecated("Use .resolve(GoogleGeofenceServiceInterface::class.java)")
 val Rover.googleGeofenceService: GoogleGeofenceServiceInterface
     get() = this.resolve(GoogleGeofenceServiceInterface::class.java) ?: throw missingDependencyError("GoogleGeofenceServiceInterface")
 

--- a/notifications/src/main/kotlin/io/rover/notifications/NotificationsAssembler.kt
+++ b/notifications/src/main/kotlin/io/rover/notifications/NotificationsAssembler.kt
@@ -314,13 +314,15 @@ class NotificationsAssembler @JvmOverloads constructor(
         )
     }
 }
-
+@Deprecated("Use .resolve(PushReceiverInterface::class.java)")
 val Rover.pushReceiver: PushReceiverInterface
     get() = this.resolve(PushReceiverInterface::class.java) ?: throw missingDependencyError("PushReceiverInterface")
 
+@Deprecated("Use .resolve(NotificationOpenInterface::class.java)")
 val Rover.notificationOpen: NotificationOpenInterface
     get() = this.resolve(NotificationOpenInterface::class.java) ?: throw missingDependencyError("NotificationOpenInterface")
 
+@Deprecated("Use .resolve(InfluenceTrackerServiceInterface::class.java)")
 val Rover.influenceTracker: InfluenceTrackerServiceInterface
     get() = this.resolve(InfluenceTrackerServiceInterface::class.java) ?: throw missingDependencyError("InfluenceTrackerService")
 

--- a/notifications/src/main/kotlin/io/rover/notifications/ui/NotificationCenterListView.kt
+++ b/notifications/src/main/kotlin/io/rover/notifications/ui/NotificationCenterListView.kt
@@ -68,8 +68,8 @@ open class NotificationCenterListView : CoordinatorLayout {
      */
     fun makeNotificationRowView(): BindableView<NotificationItemViewModelInterface> {
         @Suppress("IMPLICIT_CAST_TO_ANY", "UNCHECKED_CAST")
-        return (Rover.sharedInstance.resolve(BindableView::class.java, "notificationItemView", context) ?: throw RuntimeException(
-            "Please be sure that NotificationsAssembler is added to Rover.init before using NotificationCenterListView."
+        return (Rover.shared?.resolve(BindableView::class.java, "notificationItemView", context) ?: throw RuntimeException(
+            "Please be sure that Rover is initialized and NotificationsAssembler is added to Rover.init before using NotificationCenterListView."
         )) as BindableView<NotificationItemViewModelInterface>
     }
 
@@ -86,12 +86,12 @@ open class NotificationCenterListView : CoordinatorLayout {
      * Documentation](https://www.rover.io/docs/android/notification-center/).
      */
     open fun makeSwipeToDeleteRevealBackgroundView(): View {
-        return Rover.sharedInstance.resolve(
+        return Rover.shared?.resolve(
             View::class.java,
             "notificationItemSwipeToDeleteBackgroundView",
             context
         ) ?: throw RuntimeException(
-            "Please be sure that NotificationsAssembler is added to Rover.init before using NotificationCenterListView."
+            "Please be sure that Rover is initialized and NotificationsAssembler is added before using NotificationCenterListView."
         )
     }
 
@@ -100,12 +100,12 @@ open class NotificationCenterListView : CoordinatorLayout {
      * [Notification].
      */
     open fun makeNotificationItemViewModel(notification: Notification): NotificationItemViewModelInterface {
-        return Rover.sharedInstance.resolve(
+        return Rover.shared?.resolve(
             NotificationItemViewModelInterface::class.java,
             null,
             notification
         ) ?: throw RuntimeException(
-            "Please be sure that NotificationsAssembler is added to Rover.init before using NotificationCenterListView."
+            "Please be sure that Rover is initialized and NotificationsAssembler is added before using NotificationCenterListView."
         )
     }
 
@@ -117,11 +117,11 @@ open class NotificationCenterListView : CoordinatorLayout {
      * implementation of this class.
      */
     open val emptyLayout
-        get() = Rover.sharedInstance.resolve(
+        get() = Rover.shared?.resolve(
             View::class.java,
             "notificationListEmptyArea",
             context
-        ) ?: throw RuntimeException("Please be sure that NotificationsAssembler is added to Rover.init before using NotificationCenterListView.")
+        ) ?: throw RuntimeException("Please be sure that Rover is initialized and NotificationsAssembler is added to Rover.init before using NotificationCenterListView.")
 
     private var viewModel: NotificationCenterListViewModelInterface? by ViewModelBinding { viewModel, subscriptionCallback ->
         swipeRefreshLayout.isRefreshing = false
@@ -237,7 +237,8 @@ open class NotificationCenterListView : CoordinatorLayout {
     }
 
     private val notificationOpen: NotificationOpenInterface by lazy {
-        Rover.sharedInstance.notificationOpen
+        Rover.shared?.resolve(NotificationOpenInterface::class.java) ?:
+        throw java.lang.RuntimeException("Please be sure that Rover is initialized and NotificationsAssembler is added to Rover.init before using NotificationCenterListView.")
     }
 
     init {
@@ -307,9 +308,8 @@ open class NotificationCenterListView : CoordinatorLayout {
             }
         }).attachToRecyclerView(itemsView)
 
-        viewModel = Rover.sharedInstance.resolve(NotificationCenterListViewModelInterface::class.java, null) ?: throw RuntimeException(
-            "NotificationCenterListViewModelInterface not registered in DI container.\n" +
-            "Ensure NotificationsAssembler() provided to Rover.initialize() before using notification center."
+        viewModel = Rover.shared?.resolve(NotificationCenterListViewModelInterface::class.java, null) ?: throw RuntimeException(
+            "Ensure Rover is initialized and NotificationsAssembler() added before using notification center."
         )
 
         viewTreeObserver.addOnGlobalLayoutListener {

--- a/ticketmaster/src/main/kotlin/io/rover/ticketmaster/TicketmasterAssembler.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/ticketmaster/TicketmasterAssembler.kt
@@ -46,5 +46,6 @@ class TicketmasterAssembler: Assembler {
     }
 }
 
+@Deprecated("Use .resolve(TicketmasterAuthorizer::class.java)")
 val Rover.ticketmasterAuthorizer: TicketmasterAuthorizer
     get() = Rover.sharedInstance.resolveSingletonOrFail(TicketmasterAuthorizer::class.java)


### PR DESCRIPTION
* Various entry points now print warnings instead of crashing when Rover is not initialized or their dependencies are otherwise not available.

* Deprecated DI direct lookup accessors.

Resolves #280.