### PR TITLE
Prevent runtime exception in rover activity upon not passing Experience ID, Campaign ID or Experience URL

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/data/domain/Attributes.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/domain/Attributes.kt
@@ -1,3 +1,7 @@
 package io.rover.sdk.data.domain
 
+/**
+ * In certain places the Rover API returns unstructured data and similarly the Rover SDK is
+ * expected to submit unstructured data in yet other places.
+ */
 typealias Attributes = Map<String, Any>

--- a/sdk/src/main/kotlin/io/rover/sdk/data/graphql/Attributes.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/graphql/Attributes.kt
@@ -4,7 +4,6 @@ import io.rover.sdk.data.domain.Attributes
 import org.json.JSONArray
 import org.json.JSONObject
 
-// TODO: move to another file, this shouldn't be Attributes.kt
 fun JSONObject.toStringHash(): Map<String, String> {
     return this.keys().asSequence().associate { key ->
         Pair(key, this.safeGetString(key))
@@ -13,7 +12,7 @@ fun JSONObject.toStringHash(): Map<String, String> {
 
 fun Attributes.encodeJson(): JSONObject {
     this.map { (_, value) ->
-        val newValue = when(value) {
+        @Suppress("UNCHECKED_CAST") val newValue = when(value) {
             is Map<*, *> -> (value as Attributes).encodeJson()
             is Collection<*> -> JSONArray(value)
             else -> value

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/containers/RoverActivity.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/containers/RoverActivity.kt
@@ -179,8 +179,8 @@ open class RoverActivity : AppCompatActivity() {
         // obtain any possibly saved state for the experience view model.  See
         // onSaveInstanceState.
         val state: Parcelable? = savedInstanceState?.getParcelable("experienceState")
-        roverViewModel = when {
-            experienceId != null && campaignId == null -> experienceViewModel(
+        when {
+            experienceId != null && campaignId == null -> roverViewModel = experienceViewModel(
                 rover,
                 RoverViewModel.ExperienceRequest.ById(experienceId!!),
                 // obtain any possibly saved state for the experience view model.  See
@@ -188,20 +188,21 @@ open class RoverActivity : AppCompatActivity() {
                 state
             )
 
-            experienceId == null && campaignId != null -> experienceViewModel(
+            // This case will become deprecated in the new routing arrangement, pending backend changes:
+            experienceId == null && campaignId != null -> roverViewModel = experienceViewModel(
                 rover,
                 RoverViewModel.ExperienceRequest.ByCampaignId(campaignId!!),
                 state
             )
 
-            experienceUrl != null -> experienceViewModel(
+            experienceUrl != null -> roverViewModel = experienceViewModel(
                 rover,
                 RoverViewModel.ExperienceRequest.ByCampaignUrl(experienceUrl!!),
                 state
             )
-            else -> throw RuntimeException(
-                "Please pass either one of CAMPAIGN_ID/EXPERIENCE_ID or EXPERIENCE_URL. Consider using RoverActivity.makeIntent()"
-            )
+            else -> {
+                log.w("Please pass either one of CAMPAIGN_ID/EXPERIENCE_ID or EXPERIENCE_URL. Consider using RoverActivity.makeIntent()")
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Prevent throwing a runtime exception in RoverActivity when the activity intent extras for CAMPAIGN_ID, EXPERIENCE_ID or EXPERIENCE_URL are not present. No matching intent extras now results in a log message