### PR TITLE
Feature/reduce public visibility

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
@@ -83,13 +83,6 @@ import java.util.concurrent.Executor
 
 /**
  * Entry point for the Rover SDK.
- *
- * The Rover SDK consists of several discrete modules, which each offer a major vertical
- * (eg. Experiences and Location) of the Rover Platform.  It's up to you to select which
- * are appropriate to activate in your app.
- *
- * Serves as a dependency injection container (a sort of backplane) for the various components of
- * the Rover SDK.
  */
 
 open class Rover(

--- a/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
@@ -94,7 +94,7 @@ open class Rover(
     /**
      * Set your Rover Account Token (API Key) here.
      */
-    private var accountToken: String? = null,
+    private var accountToken: String,
 
     /**
      * Set the background colour for the Custom Chrome tabs that are used for presenting web content

--- a/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
@@ -91,77 +91,76 @@ import java.util.concurrent.Executor
  * Serves as a dependency injection container (a sort of backplane) for the various components of
  * the Rover SDK.
  */
+
 open class Rover(
     /**
      * When initializing Rover you must give it a reference
      */
-    open val application: Application,
+    private val application: Application,
 
     /**
      * Set your Rover Account Token (API Key) here.
      */
-    open var accountToken: String? = null,
+    private var accountToken: String? = null,
 
     /**
      * Set the background colour for the Custom Chrome tabs that are used for presenting web content
      * in a web browser.
      */
-    open val chromeTabBackgroundColor: Int,
+    private val chromeTabBackgroundColor: Int
+) {
+    private val endpoint: String = "https://api.rover.io/graphql"
 
-    open val endpoint: String = "https://api.rover.io/graphql",
+    private val mainScheduler: Scheduler = Scheduler.forAndroidMainThread()
 
-    open val mainScheduler: Scheduler = Scheduler.forAndroidMainThread(),
+    private val ioExecutor: Executor = IoMultiplexingExecutor.build("io")
 
-    open val ioExecutor: Executor = IoMultiplexingExecutor.build("io"),
-
-    open val ioScheduler: Scheduler = Scheduler.forExecutor(
+    private val ioScheduler: Scheduler = Scheduler.forExecutor(
         ioExecutor
-    ),
+    )
 
-    open val imageDownloader: ImageDownloader = ImageDownloader(ioExecutor),
+    private val imageDownloader: ImageDownloader = ImageDownloader(ioExecutor)
 
-    open val assetService: AndroidAssetService = AndroidAssetService(imageDownloader, ioScheduler, mainScheduler),
+    private val assetService: AndroidAssetService = AndroidAssetService(imageDownloader, ioScheduler, mainScheduler)
 
-    open val imageOptimizationService: ImageOptimizationService = ImageOptimizationService(),
+    private val imageOptimizationService: ImageOptimizationService = ImageOptimizationService()
 
-    open val httpClient: HttpClient = HttpClient(ioScheduler),
+    private val httpClient: HttpClient = HttpClient(ioScheduler)
 
-    open val webBrowserDisplay: EmbeddedWebBrowserDisplay = EmbeddedWebBrowserDisplay(chromeTabBackgroundColor),
+    internal val webBrowserDisplay: EmbeddedWebBrowserDisplay = EmbeddedWebBrowserDisplay(chromeTabBackgroundColor)
 
-    open val localStorage: LocalStorage = LocalStorage(application),
+    private val localStorage: LocalStorage = LocalStorage(application)
 
-    open val sessionStore: SessionStore = SessionStore(localStorage),
+    private val sessionStore: SessionStore = SessionStore(localStorage)
 
-    open val eventEmitter: EventEmitter = EventEmitter(),
+    /**
+     * Public in order to be accessible for capturing events for analytics and automation.
+     */
+    val eventEmitter: EventEmitter = EventEmitter()
 
-    val analyticsService: AnalyticsService = AnalyticsService(
+    private val analyticsService: AnalyticsService = AnalyticsService(
         application,
         accountToken,
         eventEmitter
-    ),
+    )
 
-    /**
-     * Not for use by typical applications: present so OAuth/SSO with apps that log into the Rover web apps can use the SDK.  You can safely ignore this.
-     */
-    open var bearerToken: String? = null,
+    private val apiService: GraphQlApiService = GraphQlApiService(URL(endpoint), accountToken, httpClient)
 
-    open val apiService: GraphQlApiService = GraphQlApiService(URL(endpoint), accountToken, bearerToken, httpClient),
+    private val sessionTracker: SessionTracker = SessionTracker(eventEmitter, sessionStore, 60)
 
-    open val sessionTracker: SessionTracker = SessionTracker(eventEmitter, sessionStore, 60),
+    private val textFormatter: AndroidRichTextToSpannedTransformer = AndroidRichTextToSpannedTransformer()
 
-    open val textFormatter: AndroidRichTextToSpannedTransformer = AndroidRichTextToSpannedTransformer(),
+    internal val barcodeRenderingService: BarcodeRenderingService = BarcodeRenderingService()
 
-    open val barcodeRenderingService: BarcodeRenderingService = BarcodeRenderingService(),
-
-    open val measurementService: MeasurementService = MeasurementService(
+    private val measurementService: MeasurementService = MeasurementService(
         displayMetrics = application.resources.displayMetrics,
         richTextToSpannedTransformer = textFormatter,
         barcodeRenderingService = barcodeRenderingService
-    ),
+    )
 
-    open val views: Views = Views()
-) {
-    open val viewModels: ViewModels by lazy {
+    internal val views: Views = Views()
+
+    internal val viewModels: ViewModels by lazy {
         ViewModels(
             apiService,
             mainScheduler,
@@ -206,17 +205,16 @@ open class Rover(
 }
 
 // TODO: consider moving entire class into appropriate sub-package
-open class ViewModels(
-//    protected open val rover: Rover
-    protected val apiService: GraphQlApiService,
-    protected val mainScheduler: Scheduler,
-    protected val eventEmitter: EventEmitter,
-    protected val sessionTracker: SessionTracker,
-    protected val imageOptimizationService: ImageOptimizationService,
-    protected val assetService: AndroidAssetService,
-    protected val measurementService: MeasurementService
+internal class ViewModels(
+    private val apiService: GraphQlApiService,
+    private val mainScheduler: Scheduler,
+    private val eventEmitter: EventEmitter,
+    private val sessionTracker: SessionTracker,
+    private val imageOptimizationService: ImageOptimizationService,
+    private val assetService: AndroidAssetService,
+    private val measurementService: MeasurementService
 ) {
-    open fun experienceViewModel(
+    fun experienceViewModel(
         experienceRequest: RoverViewModel.ExperienceRequest,
         campaignId: String?,
         activityLifecycle: Lifecycle
@@ -225,18 +223,17 @@ open class ViewModels(
             experienceRequest = experienceRequest,
             graphQlApiService = apiService,
             mainThreadScheduler = mainScheduler,
-            sessionTracker = sessionTracker,
             resolveNavigationViewModel = { experience, icicle ->
                 experienceNavigationViewModel(experience, campaignId, activityLifecycle, icicle)
             }
         )
     }
 
-    open fun experienceToolbarViewModel(toolbarConfiguration: ToolbarConfiguration): ExperienceToolbarViewModel {
+    private fun experienceToolbarViewModel(toolbarConfiguration: ToolbarConfiguration): ExperienceToolbarViewModel {
         return ExperienceToolbarViewModel(toolbarConfiguration)
     }
 
-    open fun experienceNavigationViewModel(
+    private fun experienceNavigationViewModel(
         experience: Experience,
         campaignId: String?,
         activityLifecycle: Lifecycle,
@@ -254,7 +251,7 @@ open class ViewModels(
         )
     }
 
-    open fun screenViewModel(
+    fun screenViewModel(
         screen: Screen
     ): ScreenViewModel {
         return ScreenViewModel(
@@ -264,7 +261,7 @@ open class ViewModels(
         )
     }
 
-    open fun backgroundViewModel(
+    private fun backgroundViewModel(
         background: Background
     ): BackgroundViewModel {
         return BackgroundViewModel(
@@ -275,7 +272,7 @@ open class ViewModels(
         )
     }
 
-    open fun rowViewModel(
+    fun rowViewModel(
         row: Row
     ): RowViewModel {
         return RowViewModel(
@@ -287,7 +284,7 @@ open class ViewModels(
         )
     }
 
-    open fun blockContentsViewModel(
+    private fun blockContentsViewModel(
         block: Block
     ): CompositeBlockViewModelInterface {
         when (block) {
@@ -345,7 +342,7 @@ open class ViewModels(
         }
     }
 
-    open fun blockViewModel(
+    private fun blockViewModel(
         block: Block,
         paddingDeflections: Set<LayoutPaddingDeflection>,
         measurable: Measurable?
@@ -357,13 +354,13 @@ open class ViewModels(
         )
     }
 
-    open fun borderViewModel(
+    private fun borderViewModel(
         border: Border
     ): BorderViewModel {
         return BorderViewModel(border)
     }
 
-    open fun textViewModel(
+    private fun textViewModel(
         text: Text,
         singleLine: Boolean
     ): TextViewModel {
@@ -374,7 +371,7 @@ open class ViewModels(
         )
     }
 
-    open fun imageViewModel(
+    private fun imageViewModel(
         image: Image?,
         containingBlock: Block
     ): ImageViewModel {
@@ -387,13 +384,13 @@ open class ViewModels(
         )
     }
 
-    open fun webViewModel(
+    private fun webViewModel(
         webView: WebView
     ): WebViewModel {
         return WebViewModel(webView)
     }
 
-    open fun barcodeViewModel(
+    private fun barcodeViewModel(
         barcode: Barcode
     ): BarcodeViewModel {
         return BarcodeViewModel(
@@ -403,7 +400,7 @@ open class ViewModels(
     }
 }
 
-open class Views {
+internal class Views {
     // TODO: consider moving into RoverView
     fun blockAndRowLayoutManager(
         layout: Layout,
@@ -415,7 +412,7 @@ open class Views {
         )
     }
 
-    open fun blockView(
+    private fun blockView(
         viewType: ViewType,
         context: Context
     ): LayoutableView<out LayoutableViewModel> {

--- a/sdk/src/main/kotlin/io/rover/sdk/assets/AndroidAssetService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/assets/AndroidAssetService.kt
@@ -19,7 +19,7 @@ import org.reactivestreams.Publisher
 import java.net.URL
 import java.util.concurrent.TimeUnit
 
-public open class AndroidAssetService(
+internal open class AndroidAssetService(
     imageDownloader: ImageDownloader,
     private val ioScheduler: Scheduler,
     private val mainThreadScheduler: Scheduler

--- a/sdk/src/main/kotlin/io/rover/sdk/assets/AssetRetrievalStage.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/assets/AssetRetrievalStage.kt
@@ -14,7 +14,7 @@ import java.net.URL
  *
  * This never faults to anything further down in the pipeline; it always retrieves from the API.
  */
-class AssetRetrievalStage(
+internal class AssetRetrievalStage(
     private val imageDownloader: ImageDownloader
 ) : SynchronousPipelineStage<URL, BufferedInputStream> {
     /**

--- a/sdk/src/main/kotlin/io/rover/sdk/assets/BitmapWarmGpuCacheStage.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/assets/BitmapWarmGpuCacheStage.kt
@@ -8,7 +8,7 @@ import java.net.URL
  *
  * This is effectively the first layer of cache.
  */
-class BitmapWarmGpuCacheStage(
+internal class BitmapWarmGpuCacheStage(
     private val nextStage: SynchronousPipelineStage<URL, Bitmap>
 ) : SynchronousPipelineStage<URL, Bitmap> {
     override fun request(input: URL): PipelineStageResult<Bitmap> {

--- a/sdk/src/main/kotlin/io/rover/sdk/assets/DecodeToBitmapStage.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/assets/DecodeToBitmapStage.kt
@@ -11,7 +11,7 @@ import java.net.URL
  * auto-detects) any image format that Android supports). We guarantee support for the image formats
  * used by Rover, specifically, GIF, JPEG and PNG.
  */
-class DecodeToBitmapStage(
+internal class DecodeToBitmapStage(
     private val priorStage: SynchronousPipelineStage<URL, BufferedInputStream>
 ) : SynchronousPipelineStage<URL, Bitmap> {
     override fun request(input: URL): PipelineStageResult<Bitmap> {

--- a/sdk/src/main/kotlin/io/rover/sdk/assets/FetchByHttp.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/assets/FetchByHttp.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.Executor
 /**
  * A simple HTTP downloader.
  */
-class ImageDownloader(
+internal class ImageDownloader(
     private val ioExecutor: Executor
 ) {
     /**

--- a/sdk/src/main/kotlin/io/rover/sdk/assets/ImageOptimizationService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/assets/ImageOptimizationService.kt
@@ -14,7 +14,7 @@ import io.rover.sdk.ui.dpAsPx
 import java.net.URI
 import kotlin.math.roundToInt
 
-open class ImageOptimizationService  {
+internal class ImageOptimizationService  {
 
     private val urlOptimizationEnabled = true
 
@@ -28,7 +28,7 @@ open class ImageOptimizationService  {
      * @return The optimized image configuration, which includes the URI with optimization
      * parameters.  May be null if the background in question has no image.
      */
-    open fun optimizeImageBackground(background: Background, targetViewPixelSize: PixelSize, density: Float): OptimizedImage? {
+    fun optimizeImageBackground(background: Background, targetViewPixelSize: PixelSize, density: Float): OptimizedImage? {
         return if (urlOptimizationEnabled) {
             imageConfigurationOptimizedByImgix(background, targetViewPixelSize, density)
         } else {
@@ -338,7 +338,7 @@ open class ImageOptimizationService  {
      *
      * @return optimized URI.
      */
-    open fun optimizeImageBlock(
+    fun optimizeImageBlock(
         image: Image,
         containingBlock: Block,
         targetViewPixelSize: PixelSize,

--- a/sdk/src/main/kotlin/io/rover/sdk/assets/InMemoryBitmapCacheStage.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/assets/InMemoryBitmapCacheStage.kt
@@ -11,7 +11,7 @@ import java.net.URL
  *
  * This is the second layer of cache.
  */
-class InMemoryBitmapCacheStage(
+internal class InMemoryBitmapCacheStage(
     private val faultTo: SynchronousPipelineStage<URL, Bitmap>
 ) : SynchronousPipelineStage<URL, Bitmap> {
 

--- a/sdk/src/main/kotlin/io/rover/sdk/assets/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/assets/Interfaces.kt
@@ -13,16 +13,16 @@ import java.net.URL
  * Stages should not block to do computation-type work, however; the asset pipeline is
  * run on a thread pool optimized for I/O multiplexing and not computation.
  */
-interface SynchronousPipelineStage<in TInput, TOutput> {
+internal interface SynchronousPipelineStage<in TInput, TOutput> {
     fun request(input: TInput): PipelineStageResult<TOutput>
 }
 
-sealed class PipelineStageResult<TOutput> {
+internal sealed class PipelineStageResult<TOutput> {
     class Successful<TOutput>(val output: TOutput) : PipelineStageResult<TOutput>()
     class Failed<TOutput>(val reason: Throwable) : PipelineStageResult<TOutput>()
 }
 
-interface AssetService {
+internal interface AssetService {
     /**
      * Subscribe to any updates for the image at URL, fully decoded and ready for display.
      *

--- a/sdk/src/main/kotlin/io/rover/sdk/assets/OptimizedImage.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/assets/OptimizedImage.kt
@@ -6,7 +6,7 @@ import java.net.URI
 /**
  * A retrieval URI and configuration needed for displaying an image.
  */
-data class OptimizedImage(
+internal data class OptimizedImage(
     /**
      * The (potentially) modified URI.
      */

--- a/sdk/src/main/kotlin/io/rover/sdk/data/events/AnalyticsService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/events/AnalyticsService.kt
@@ -3,7 +3,6 @@ package io.rover.sdk.data.events
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.AsyncTask
-import android.os.Build
 import io.rover.sdk.data.domain.Attributes
 import io.rover.sdk.data.graphql.encodeJson
 import io.rover.sdk.data.http.HttpRequest
@@ -16,18 +15,16 @@ import org.json.JSONObject
 import java.io.DataOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
-import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
 import java.util.UUID
 
 /**
  * Responsible for dispatching Analytics events.
  */
-class AnalyticsService(
+internal class AnalyticsService(
     context: Context,
     private val accountToken: String?,
-    private val eventEmitter: EventEmitter
+    eventEmitter: EventEmitter
 ) {
 
     private val prefs: SharedPreferences? =
@@ -83,11 +80,14 @@ class AnalyticsService(
         request(urlRequest, bodyData)
     }
 
-    fun enable() {
+    /**
+     * Initiates the [AnalyticsService] sending of analytics events.
+     */
+    init {
         eventEmitter.trackedEvents.subscribe { sendRequest(it) }
     }
 
-    fun request(
+    internal fun request(
         request: HttpRequest,
         bodyData: String
     ) {

--- a/sdk/src/main/kotlin/io/rover/sdk/data/events/AnalyticsService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/events/AnalyticsService.kt
@@ -87,7 +87,7 @@ internal class AnalyticsService(
         eventEmitter.trackedEvents.subscribe { sendRequest(it) }
     }
 
-    internal fun request(
+    private fun request(
         request: HttpRequest,
         bodyData: String
     ) {

--- a/sdk/src/main/kotlin/io/rover/sdk/data/events/RoverEvent.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/events/RoverEvent.kt
@@ -13,7 +13,7 @@ import io.rover.sdk.data.operations.data.encodeJson
 import org.json.JSONObject
 
 sealed class RoverEvent {
-    abstract fun encodeJson(): JSONObject
+    internal abstract fun encodeJson(): JSONObject
 
     data class BlockTapped(
         val experience: Experience,
@@ -33,7 +33,7 @@ sealed class RoverEvent {
             }
         }
 
-        companion object {
+        internal companion object {
             fun decodeJson(jsonObject: JSONObject): BlockTapped {
                 return BlockTapped(
                     experience = Experience.decodeJson(jsonObject.getJSONObject(BlockTapped::experience.name)),
@@ -61,7 +61,7 @@ sealed class RoverEvent {
             }
         }
 
-        companion object {
+        internal companion object {
             fun decodeJson(jsonObject: JSONObject): ExperienceDismissed {
                 return ExperienceDismissed(
                     experience = Experience.decodeJson(jsonObject.getJSONObject(ExperienceDismissed::experience.name)),
@@ -88,7 +88,7 @@ sealed class RoverEvent {
             }
         }
 
-        companion object {
+        internal companion object {
             fun decodeJson(jsonObject: JSONObject): ScreenDismissed {
                 return ScreenDismissed(
                     experience = Experience.decodeJson(jsonObject.getJSONObject(ScreenDismissed::experience.name)),
@@ -114,7 +114,7 @@ sealed class RoverEvent {
             }
         }
 
-        companion object {
+        internal companion object {
             fun decodeJson(jsonObject: JSONObject): ExperiencePresented {
                 return ExperiencePresented(
                     experience = Experience.decodeJson(jsonObject.getJSONObject(ExperiencePresented::experience.name)),
@@ -141,7 +141,7 @@ sealed class RoverEvent {
             }
         }
 
-        companion object {
+        internal companion object {
             fun decodeJson(jsonObject: JSONObject, duration: Int = 0): ExperienceViewed {
                 return ExperienceViewed(
                     experience = Experience.decodeJson(jsonObject.getJSONObject(ScreenDismissed::experience.name)),
@@ -168,7 +168,7 @@ sealed class RoverEvent {
             }
         }
 
-        companion object {
+        internal companion object {
             fun decodeJson(jsonObject: JSONObject, duration: Int = 0): ScreenViewed {
                 return ScreenViewed(
                     experience = Experience.decodeJson(jsonObject.getJSONObject(BlockTapped::experience.name)),
@@ -197,7 +197,7 @@ sealed class RoverEvent {
             }
         }
 
-        companion object {
+        internal companion object {
             fun decodeJson(jsonObject: JSONObject): ScreenPresented {
                 return ScreenPresented(
                     experience = Experience.decodeJson(jsonObject.getJSONObject(ScreenPresented::experience.name)),
@@ -208,7 +208,7 @@ sealed class RoverEvent {
         }
     }
 
-    companion object {
+    internal companion object {
         private const val BLOCK_TAPPED_CODE = "BLOCK TAPPED"
         private const val EXPERIENCE_DISMISSED_CODE = "EXPERIENCE DISMISSED"
         private const val SCREEN_DISMISSED_CODE = "SCREEN DISMISSED"

--- a/sdk/src/main/kotlin/io/rover/sdk/data/graphql/Attributes.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/graphql/Attributes.kt
@@ -4,13 +4,13 @@ import io.rover.sdk.data.domain.Attributes
 import org.json.JSONArray
 import org.json.JSONObject
 
-fun JSONObject.toStringHash(): Map<String, String> {
+internal fun JSONObject.toStringHash(): Map<String, String> {
     return this.keys().asSequence().associate { key ->
         Pair(key, this.safeGetString(key))
     }
 }
 
-fun Attributes.encodeJson(): JSONObject {
+internal fun Attributes.encodeJson(): JSONObject {
     this.map { (_, value) ->
         @Suppress("UNCHECKED_CAST") val newValue = when(value) {
             is Map<*, *> -> (value as Attributes).encodeJson()
@@ -22,7 +22,7 @@ fun Attributes.encodeJson(): JSONObject {
     return JSONObject(this)
 }
 
-fun JSONObject.toAttributesHash(): Attributes {
+internal fun JSONObject.toAttributesHash(): Attributes {
     return this.keys().asSequence().map { key ->
         val value = get(key)
         if (value is JSONObject) {

--- a/sdk/src/main/kotlin/io/rover/sdk/data/graphql/GraphQlApiService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/graphql/GraphQlApiService.kt
@@ -17,10 +17,9 @@ import java.net.URL
 /**
  * Responsible for providing access the Rover cloud API, powered by GraphQL.
  */
-open class GraphQlApiService(
+internal class GraphQlApiService(
     private val endpoint: URL,
     private val accountToken: String?,
-    private val bearerToken: String?,
     private val httpClient: HttpClient
 ) {
     private fun urlRequest(mutation: Boolean, queryParams: Map<String, String>): HttpRequest {
@@ -37,7 +36,6 @@ open class GraphQlApiService(
 
                 when {
                     accountToken != null -> this["x-rover-account-token"] = accountToken
-                    bearerToken != null -> this["authorization"] = "Bearer $bearerToken"
                 }
 
                 this.entries.forEach { (key, value) ->
@@ -119,7 +117,7 @@ open class GraphQlApiService(
     /**
      * Performs the given [GraphQlRequest] when subscribed and yields the result to the subscriber.
      */
-    open fun <TEntity> operation(request: GraphQlRequest<TEntity>): Publisher<ApiResult<TEntity>> {
+    fun <TEntity> operation(request: GraphQlRequest<TEntity>): Publisher<ApiResult<TEntity>> {
         // TODO: once we change urlRequest() to use query parameters and GET for non-mutation
         // requests, replace true `below` with `request.mutation`.
         val urlRequest = urlRequest(request.mutation, request.encodeQueryParameters())
@@ -135,7 +133,7 @@ open class GraphQlApiService(
     /**
      * Retrieves the experience when subscribed and yields it to the subscriber.
      */
-    open fun fetchExperience(
+    fun fetchExperience(
         query: FetchExperienceRequest.ExperienceQueryIdentifier
     ): Publisher<ApiResult<Experience>> {
         return this.operation(

--- a/sdk/src/main/kotlin/io/rover/sdk/data/graphql/JSONExtensions.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/graphql/JSONExtensions.kt
@@ -16,7 +16,7 @@ import kotlin.reflect.KProperty1
  *
  * This method returns an optional Kotlin boxed [Int] value.
  */
-fun JSONObject.optIntOrNull(name: String): Int? {
+internal fun JSONObject.optIntOrNull(name: String): Int? {
     val value = opt(name)
     return when (value) {
         is Int -> value
@@ -41,7 +41,7 @@ fun JSONObject.optIntOrNull(name: String): Int? {
  *
  * See [Android Bug #36924550](https://issuetracker.google.com/issues/36924550).
  */
-fun JSONObject.safeOptString(name: String): String? {
+internal fun JSONObject.safeOptString(name: String): String? {
     return if (isNull(name)) null else optString(name, null)
 }
 
@@ -54,14 +54,14 @@ fun JSONObject.safeOptString(name: String): String? {
  *
  * See [Android Bug #36924550](https://issuetracker.google.com/issues/36924550).
  */
-fun JSONObject.safeGetString(name: String): String {
+internal fun JSONObject.safeGetString(name: String): String {
     if (isNull(name)) {
         throw JSONException("Field '$name' is null instead of string")
     }
     return getString(name)
 }
 
-fun JSONObject.safeGetUri(name: String): URI {
+internal fun JSONObject.safeGetUri(name: String): URI {
     val field = this.safeGetString(name)
 //    if(field == "") {
 //        throw JSONException("Invalid URI.  Must not be an empty string.")
@@ -80,22 +80,22 @@ fun JSONObject.safeGetUri(name: String): URI {
 /**
  * The stock [JSONObject.optBoolean] method cannot tell you if the value was unset or not present.
  */
-fun JSONObject.safeOptBoolean(name: String): Boolean? {
+internal fun JSONObject.safeOptBoolean(name: String): Boolean? {
     return if (isNull(name) || !this.has(name)) null else optBoolean(name)
 }
 
-fun JSONObject.safeOptInt(name: String): Int? {
+internal fun JSONObject.safeOptInt(name: String): Int? {
     return if (isNull(name) || !this.has(name)) null else optInt(name)
 }
 
-fun <T, R> JSONObject.putProp(obj: T, prop: KProperty1<T, R>, transform: ((R) -> Any?)? = null) {
+internal fun <T, R> JSONObject.putProp(obj: T, prop: KProperty1<T, R>, transform: ((R) -> Any?)? = null) {
     put(
         prop.name,
         if (transform != null) transform(prop.get(obj)) else prop.get(obj)
     )
 }
 
-fun <T, R> JSONObject.putProp(obj: T, prop: KProperty1<T, R>, name: String, transform: ((R) -> Any?)? = null) {
+internal fun <T, R> JSONObject.putProp(obj: T, prop: KProperty1<T, R>, name: String, transform: ((R) -> Any?)? = null) {
     put(
         name,
         if (transform != null) transform(prop.get(obj)) else prop.get(obj)
@@ -105,15 +105,15 @@ fun <T, R> JSONObject.putProp(obj: T, prop: KProperty1<T, R>, name: String, tran
 /**
  * Get an [Iterable] over a [JSONArray], assuming/coercing all within to be strings.
  */
-fun JSONArray.getStringIterable(): Iterable<String> = getIterable()
+internal fun JSONArray.getStringIterable(): Iterable<String> = getIterable()
 
 /**
  * Get an [Iterable] over a [JSONArray], assuming/coercing all within to be [JSONObject]s.
  */
-fun JSONArray.getObjectIterable(): Iterable<JSONObject> = getIterable()
+internal fun JSONArray.getObjectIterable(): Iterable<JSONObject> = getIterable()
 
 @Suppress("UNCHECKED_CAST")
-fun <T> JSONArray.getIterable(): Iterable<T> {
+internal fun <T> JSONArray.getIterable(): Iterable<T> {
     return object : Iterable<T> {
         private var counter = 0
         override fun iterator(): Iterator<T> {

--- a/sdk/src/main/kotlin/io/rover/sdk/data/graphql/Types.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/graphql/Types.kt
@@ -8,7 +8,7 @@ import org.json.JSONObject
  *
  * @param TInput This is the type of the reply you expect to arrive back from the cloud API.
  */
-interface GraphQlRequest<out TInput> {
+internal interface GraphQlRequest<out TInput> {
     /**
      * A GraphQL operation name that should be selected out of the query.  Optional.
      */
@@ -105,7 +105,7 @@ interface GraphQlRequest<out TInput> {
  * A network response.  Optionally either a success (with requested payload), or a failure (with the
  * reason why, and whether or not the caller ought to attempt to repeat the request.
  */
-sealed class ApiResult<T> {
+internal sealed class ApiResult<T> {
     data class Error<T>(
         val throwable: Throwable,
 
@@ -121,7 +121,7 @@ sealed class ApiResult<T> {
     data class Success<T>(val response: T) : ApiResult<T>()
 }
 
-sealed class ApiError(
+internal sealed class ApiError(
     private val description: String
 ) : Exception(description) {
     class EmptyResponseData : ApiError("Empty response data")
@@ -136,6 +136,6 @@ sealed class ApiError(
     }
 }
 
-class APIException(
+internal class APIException(
     val errors: List<Exception>
 ) : Exception("Rover API reported: ${errors.map { it.message }.joinToString(", ")}")

--- a/sdk/src/main/kotlin/io/rover/sdk/data/http/HttpClient.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/http/HttpClient.kt
@@ -21,7 +21,7 @@ import javax.net.ssl.HttpsURLConnection
  * HTTP client (used for both Rover API access and other tasks), powered by Android's stock
  * [HttpsURLConnection].
  */
-open class HttpClient(
+internal class HttpClient(
     private val ioScheduler: Scheduler
 )  {
     /**
@@ -31,7 +31,7 @@ open class HttpClient(
      * Thus, it is called on the background worker thread to allow for client code to read those
      * streams, safely away from the Android main UI thread.
      */
-    open fun request(
+    fun request(
         request: HttpRequest,
         bodyData: String?
     ): Publisher<HttpClientResponse> {

--- a/sdk/src/main/kotlin/io/rover/sdk/data/http/Types.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/http/Types.kt
@@ -3,19 +3,19 @@ package io.rover.sdk.data.http
 import java.io.BufferedInputStream
 import java.net.URL
 
-enum class HttpVerb(
+internal enum class HttpVerb(
     val wireFormat: String
 ) {
     GET("GET"), POST("POST"), PUT("PUT"), DELETE("DELETE")
 }
 
-data class HttpRequest(
+internal data class HttpRequest(
     val url: URL,
     val headers: HashMap<String, String>,
     val verb: HttpVerb
 )
 
-sealed class HttpClientResponse {
+internal sealed class HttpClientResponse {
     class Success(
         /**
          * The HTTP request has gotten a successful reply, and now the server is streaming the

--- a/sdk/src/main/kotlin/io/rover/sdk/data/operations/FetchExperienceRequest.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/operations/FetchExperienceRequest.kt
@@ -5,7 +5,7 @@ import io.rover.sdk.data.graphql.GraphQlRequest
 import io.rover.sdk.data.operations.data.decodeJson
 import org.json.JSONObject
 
-class FetchExperienceRequest(
+internal class FetchExperienceRequest(
     private val queryIdentifier: ExperienceQueryIdentifier
 ) : GraphQlRequest<Experience> {
     override val operationName: String = "FetchExperience"

--- a/sdk/src/main/kotlin/io/rover/sdk/data/operations/data/Experience.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/operations/data/Experience.kt
@@ -47,7 +47,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-fun Experience.Companion.decodeJson(json: JSONObject): Experience {
+internal fun Experience.Companion.decodeJson(json: JSONObject): Experience {
     return Experience(
         id = ID(json.safeGetString("id")),
         homeScreenId = ID(json.safeGetString("homeScreenID")),
@@ -410,7 +410,7 @@ internal fun Image.encodeJson(): JSONObject {
     }
 }
 
-fun Background.Companion.decodeJson(json: JSONObject): Background {
+internal fun Background.Companion.decodeJson(json: JSONObject): Background {
     return Background(
         color = Color.decodeJson(json.getJSONObject("color")),
         contentMode = BackgroundContentMode.decodeJSON(json.safeGetString("contentMode")),
@@ -419,7 +419,7 @@ fun Background.Companion.decodeJson(json: JSONObject): Background {
     )
 }
 
-fun Border.Companion.decodeJson(json: JSONObject): Border {
+internal fun Border.Companion.decodeJson(json: JSONObject): Border {
     return Border(
         color = Color.decodeJson(json.getJSONObject("color")),
         radius = json.getInt("radius"),
@@ -427,7 +427,7 @@ fun Border.Companion.decodeJson(json: JSONObject): Border {
     )
 }
 
-fun Text.Companion.decodeJson(json: JSONObject): Text {
+internal fun Text.Companion.decodeJson(json: JSONObject): Text {
     return Text(
         rawValue = json.safeGetString("rawValue"),
         alignment = TextAlignment.decodeJson(json.safeGetString("alignment")),

--- a/sdk/src/main/kotlin/io/rover/sdk/logging/LoggingExtensions.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/logging/LoggingExtensions.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.Executors
 /**
  * A very simple facade wrapped around the Android logger using Kotlin extension methods.
  */
-interface LogReceiver {
+internal interface LogReceiver {
     fun e(message: String)
     fun w(message: String)
     fun v(message: String)
@@ -15,7 +15,7 @@ interface LogReceiver {
     fun d(message: String)
 }
 
-interface LogEmitter {
+internal interface LogEmitter {
     fun e(logTag: String, message: String)
     fun w(logTag: String, message: String)
     fun v(logTag: String, message: String)
@@ -23,7 +23,7 @@ interface LogEmitter {
     fun d(logTag: String, message: String)
 }
 
-class GlobalStaticLogHolder {
+internal class GlobalStaticLogHolder {
     companion object {
         // This is the only example of a global scope, mutable, allocated-at-runtime value.  This is
         // to avoid the complexity of trying to inject a logger into all and sundry location.
@@ -35,7 +35,7 @@ class GlobalStaticLogHolder {
     }
 }
 
-val Any.log: LogReceiver
+internal val Any.log: LogReceiver
     get() {
         val receiver = GlobalStaticLogHolder.globalLogEmitter ?: AndroidLogger() // default to a simple Android logger if logger not configured.
 
@@ -65,7 +65,7 @@ val Any.log: LogReceiver
         }
     }
 
-class AndroidLogger : LogEmitter {
+internal class AndroidLogger : LogEmitter {
     override fun e(logTag: String, message: String) {
         Log.e(logTag, message)
     }
@@ -87,7 +87,7 @@ class AndroidLogger : LogEmitter {
     }
 }
 
-class JvmLogger : LogEmitter {
+internal class JvmLogger : LogEmitter {
     override fun e(logTag: String, message: String) {
         System.out.println("E/$logTag $message")
     }
@@ -114,7 +114,7 @@ class JvmLogger : LogEmitter {
  * [bufferLineSize] of those log messages such that they can be retrieved, perhaps to include with a
  * crash report or similar.
  */
-class LogBuffer(
+internal class LogBuffer(
     private val nextLogger: LogEmitter,
     private val bufferLineSize: Int = 40
 ) : LogEmitter by nextLogger {

--- a/sdk/src/main/kotlin/io/rover/sdk/platform/AnyExtensions.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/AnyExtensions.kt
@@ -5,7 +5,7 @@ package io.rover.sdk.platform
 /**
  * Use this extension method evaluate an expression against a value when it is not null.
  */
-fun <T : Any, R : Any> T?.whenNotNull(cb: (T) -> R?): R? {
+internal fun <T : Any, R : Any> T?.whenNotNull(cb: (T) -> R?): R? {
     return if (this != null) {
         cb(this)
     } else {

--- a/sdk/src/main/kotlin/io/rover/sdk/platform/DrawableWrapper.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/DrawableWrapper.kt
@@ -36,9 +36,9 @@ import android.view.View
  *
  * @hide
  */
-open class DrawableWrapper(drawable: Drawable) : Drawable(), Drawable.Callback {
+internal open class DrawableWrapper(drawable: Drawable) : Drawable(), Drawable.Callback {
 
-    var wrappedDrawable: Drawable? = null
+    private var wrappedDrawable: Drawable? = null
         set(drawable) {
             if (wrappedDrawable != null) {
                 wrappedDrawable!!.callback = null

--- a/sdk/src/main/kotlin/io/rover/sdk/platform/IoMultiplexingExecutor.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/IoMultiplexingExecutor.kt
@@ -11,10 +11,8 @@ import java.util.concurrent.TimeUnit
 /**
  * A builder that will produce an [Executor] suitable for multiplexing across many blocking I/O
  * operations.
- *
- * TODO make internal again after DI fixes.
  */
-class IoMultiplexingExecutor {
+internal class IoMultiplexingExecutor {
     companion object {
         /**
          * This will produce an [Executor] tuned for multiplexing I/O, not for computation.
@@ -23,7 +21,7 @@ class IoMultiplexingExecutor {
          */
         @SuppressLint("NewApi")
         @JvmStatic
-        fun build(executorName: String): Executor {
+        internal fun build(executorName: String): Executor {
             val alwaysUseLegacyThreadPool = false
 
             val cpuCount = Runtime.getRuntime().availableProcessors()

--- a/sdk/src/main/kotlin/io/rover/sdk/platform/IoMultiplexingExecutor.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/IoMultiplexingExecutor.kt
@@ -21,7 +21,7 @@ internal class IoMultiplexingExecutor {
          */
         @SuppressLint("NewApi")
         @JvmStatic
-        internal fun build(executorName: String): Executor {
+        fun build(executorName: String): Executor {
             val alwaysUseLegacyThreadPool = false
 
             val cpuCount = Runtime.getRuntime().availableProcessors()

--- a/sdk/src/main/kotlin/io/rover/sdk/platform/LocalStorage.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/LocalStorage.kt
@@ -7,7 +7,7 @@ import android.content.SharedPreferences
 /**
  * Very simple hash-like storage of keys and values.
  */
-interface KeyValueStorage {
+internal interface KeyValueStorage {
     /**
      * Get the current value of the given key, or null if unset.
      */
@@ -29,12 +29,13 @@ interface KeyValueStorage {
 /**
  *  Obtain a persistent key-value named persistent storage area using Android's [SharedPreferences].
  */
-open class LocalStorage(
+internal class LocalStorage(
     private val androidContext: Context,
     private val baseContextName: String = "io.rover.localstorage"
-)  {
-    open fun getKeyValueStorageFor(namedContext: String): KeyValueStorage {
-        val prefs = androidContext.getSharedPreferences("$baseContextName.$namedContext", MODE_PRIVATE)
+) {
+    fun getKeyValueStorageFor(namedContext: String): KeyValueStorage {
+        val prefs =
+            androidContext.getSharedPreferences("$baseContextName.$namedContext", MODE_PRIVATE)
         return object : KeyValueStorage {
             override fun get(key: String): String? = prefs.getString(key, null)
 

--- a/sdk/src/main/kotlin/io/rover/sdk/platform/MapExtensions.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/MapExtensions.kt
@@ -4,7 +4,7 @@ package io.rover.sdk.platform
  * Merge two hashes together. In the event of the same key existing, [transform] is invoked to
  * merge the two values.
  */
-fun <TKey, TValue> Map<TKey, TValue>.merge(other: Map<TKey, TValue>, transform: (TValue, TValue) -> TValue): Map<TKey, TValue> {
+internal fun <TKey, TValue> Map<TKey, TValue>.merge(other: Map<TKey, TValue>, transform: (TValue, TValue) -> TValue): Map<TKey, TValue> {
     val keysSet = this.keys + other.keys
 
     return keysSet.map { key ->

--- a/sdk/src/main/kotlin/io/rover/sdk/platform/StringExtensions.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/StringExtensions.kt
@@ -6,7 +6,7 @@ import android.os.Build
 import android.text.Html
 import android.text.SpannableStringBuilder
 
-fun String.roverTextHtmlAsSpanned(): SpannableStringBuilder {
+internal fun String.roverTextHtmlAsSpanned(): SpannableStringBuilder {
     return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
         @Suppress("DEPRECATION")
         val spannedBuilder = Html.fromHtml(this) as SpannableStringBuilder
@@ -38,14 +38,4 @@ fun String.roverTextHtmlAsSpanned(): SpannableStringBuilder {
     } else {
         Html.fromHtml(this, Html.FROM_HTML_SEPARATOR_LINE_BREAK_PARAGRAPH) as SpannableStringBuilder
     }
-}
-
-/**
- * Parse the given string as URI query parameters.
- */
-fun String.parseAsQueryParameters(): Map<String, String> {
-    return split("&").map {
-        val keyAndValue = it.split("=")
-        Pair(keyAndValue.first(), keyAndValue[1])
-    }.associate { it }
 }

--- a/sdk/src/main/kotlin/io/rover/sdk/platform/UriExtensions.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/UriExtensions.kt
@@ -5,4 +5,4 @@ package io.rover.sdk.platform
 import android.net.Uri
 import java.net.URI
 
-fun URI.asAndroidUri(): Uri = Uri.parse(this.toString())
+internal fun URI.asAndroidUri(): Uri = Uri.parse(this.toString())

--- a/sdk/src/main/kotlin/io/rover/sdk/platform/ZXingExtensions.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/ZXingExtensions.kt
@@ -27,7 +27,7 @@ import io.rover.shaded.zxing.com.google.zxing.common.BitMatrix
 /**
  * Convert a [BitMatrix] bitmap from ZXing to an Android [Bitmap].
  */
-fun BitMatrix.toAndroidBitmap(): Bitmap {
+internal fun BitMatrix.toAndroidBitmap(): Bitmap {
     // More or less obtained from zxing/client/android/encode/QRCodeEncoder.java
     val pixels = IntArray(width * height)
     for (y in 0 until height) {

--- a/sdk/src/main/kotlin/io/rover/sdk/services/BarcodeRenderingService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/BarcodeRenderingService.kt
@@ -12,7 +12,7 @@ import io.rover.shaded.zxing.com.google.zxing.EncodeHintType
 import io.rover.shaded.zxing.com.google.zxing.MultiFormatWriter
 import io.rover.shaded.zxing.com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
 
-open class BarcodeRenderingService {
+internal class BarcodeRenderingService {
     enum class Format {
         Pdf417, Code128, Aztec, QrCode
     }
@@ -28,7 +28,7 @@ open class BarcodeRenderingService {
      * Returns the height needed to accommodate the barcode, at the correct aspect, at the given
      * width, in points.
      */
-    open fun measureHeightNeededForBarcode(
+    fun measureHeightNeededForBarcode(
         text: String,
         format: Format,
         width: Float
@@ -43,7 +43,7 @@ open class BarcodeRenderingService {
      *
      * Note that what length and sort of text is valid depends on the Barcode format.
      */
-    open fun renderBarcode(
+    fun renderBarcode(
         text: String,
         format: Format
     ): Bitmap {

--- a/sdk/src/main/kotlin/io/rover/sdk/services/EmbeddedWebBrowserDisplay.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/EmbeddedWebBrowserDisplay.kt
@@ -17,7 +17,7 @@ interface EmbeddedWebBrowserDisplayInterface {
     fun intentForViewingWebsiteViaEmbeddedBrowser(url: String): Intent
 }
 
-class EmbeddedWebBrowserDisplay(
+internal class EmbeddedWebBrowserDisplay(
     /**
      * Set the background colour for the Chrome Custom tab's title bar.
      *

--- a/sdk/src/main/kotlin/io/rover/sdk/services/EventEmitter.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/EventEmitter.kt
@@ -12,12 +12,12 @@ import org.reactivestreams.Publisher
  *
  * Alternatively, you can add a [RoverEventListener] to receive event updates
  */
-open class EventEmitter {
-    protected open val eventSubject = PublishSubject<RoverEvent>()
+class EventEmitter {
+    private val eventSubject = PublishSubject<RoverEvent>()
 
-    open val trackedEvents: Publisher<RoverEvent> by lazy { eventSubject.share() }
+    val trackedEvents: Publisher<RoverEvent> by lazy { eventSubject.share() }
 
-    open fun trackEvent(roverEvent: RoverEvent) {
+    internal fun trackEvent(roverEvent: RoverEvent) {
         eventSubject.onNext(roverEvent)
         when (roverEvent) {
             is RoverEvent.BlockTapped -> listeners.forEach { it.onBlockTapped(roverEvent) }

--- a/sdk/src/main/kotlin/io/rover/sdk/services/MeasurementService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/MeasurementService.kt
@@ -15,7 +15,7 @@ import io.rover.sdk.ui.blocks.concerns.text.RichTextToSpannedTransformer
 import io.rover.sdk.ui.dpAsPx
 import io.rover.sdk.ui.pxAsDp
 
-open class MeasurementService(
+internal class MeasurementService(
     private val displayMetrics: DisplayMetrics,
     private val richTextToSpannedTransformer: RichTextToSpannedTransformer,
     private val barcodeRenderingService: BarcodeRenderingService
@@ -32,7 +32,7 @@ open class MeasurementService(
      * Returns the height needed to accommodate the text at the given width, in dps.
      */
     @SuppressLint("NewApi")
-    open fun measureHeightNeededForRichText(
+    fun measureHeightNeededForRichText(
         richText: String,
         fontAppearance: FontAppearance,
         boldFontAppearance: Font,
@@ -102,7 +102,7 @@ open class MeasurementService(
      * Returns the height needed to accommodate the barcode, at the correct aspect, at the given
      * width, in dps.
      */
-    open fun measureHeightNeededForBarcode(
+    fun measureHeightNeededForBarcode(
         text: String,
         type: BarcodeViewModelInterface.BarcodeType,
         width: Float

--- a/sdk/src/main/kotlin/io/rover/sdk/services/SessionTracker.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/SessionTracker.kt
@@ -13,7 +13,7 @@ import java.util.Date
 import java.util.UUID
 import kotlin.math.max
 
-open class SessionTracker(
+internal class SessionTracker(
     private val eventEmitter: EventEmitter,
 
     private val sessionStore: SessionStore,
@@ -38,7 +38,7 @@ open class SessionTracker(
      * A [sessionEventName] must be provided so that the Session Tracker can emit session viewed
      * after the timeout completes.
      */
-    open fun enterSession(
+    fun enterSession(
         sessionKey: Any,
         sessionStartEvent: RoverEvent,
         sessionEvent: RoverEvent
@@ -89,7 +89,7 @@ open class SessionTracker(
         updateTimer()
     }
 
-    open fun leaveSession(
+    fun leaveSession(
         sessionKey: Any,
         sessionEndEvent: RoverEvent
     ) {
@@ -102,7 +102,7 @@ open class SessionTracker(
     }
 }
 
-open class SessionStore(
+internal class SessionStore(
     localStorage: LocalStorage
 ) {
     private val store = localStorage.getKeyValueStorageFor(STORAGE_IDENTIFIER)
@@ -116,7 +116,7 @@ open class SessionStore(
      *
      * Returns the new session's UUID, or, if a session is already active, null.
      */
-    open fun enterSession(sessionKey: Any, sessionEvent: RoverEvent) {
+    fun enterSession(sessionKey: Any, sessionEvent: RoverEvent) {
         val session = getEntry(sessionKey)?.copy(
             // clear closedAt to avoid expiring the session if it is being re-opened.
             closedAt = null
@@ -130,7 +130,7 @@ open class SessionStore(
         setEntry(sessionKey, session)
     }
 
-    open fun leaveSession(sessionKey: Any) {
+    fun leaveSession(sessionKey: Any) {
         val existingEntry = getEntry(sessionKey)
 
         if (existingEntry != null) {
@@ -163,7 +163,7 @@ open class SessionStore(
     /**
      * Returns the soonest time that a session is going to expire.
      */
-    open fun soonestExpiryInSeconds(keepAliveSeconds: Int): Int? {
+    fun soonestExpiryInSeconds(keepAliveSeconds: Int): Int? {
         // gather stale expiring session entries that have passed.
         val earliestExpiry = store.keys
             .mapNotNull { key -> getEntry(key) }
@@ -188,7 +188,7 @@ open class SessionStore(
      *
      * Such sessions will only be returned once; they are deleted.
      */
-    open fun collectExpiredSessions(keepAliveSeconds: Int): List<ExpiredSession> {
+    fun collectExpiredSessions(keepAliveSeconds: Int): List<ExpiredSession> {
         val expiringEntries = store.keys
             .mapNotNull { key ->
                 getEntry(key).whenNotNull { Pair(key, it) }
@@ -217,7 +217,7 @@ open class SessionStore(
         }
     }
 
-    open fun gc() {
+    private fun gc() {
         log.v("Garbage collecting any expired sessions.")
 
         store.keys.forEach { key ->

--- a/sdk/src/main/kotlin/io/rover/sdk/streams/Android.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/streams/Android.kt
@@ -9,7 +9,7 @@ import android.view.View
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscription
 
-sealed class ViewEvent {
+internal sealed class ViewEvent {
     class Attach : ViewEvent()
     class Detach : ViewEvent()
 }
@@ -17,7 +17,7 @@ sealed class ViewEvent {
 /**
  * Observe attach and detach events from the given Android [View].
  */
-fun View.attachEvents(): Publisher<ViewEvent> {
+internal fun View.attachEvents(): Publisher<ViewEvent> {
     return Publisher { subscriber ->
         var requested = false
         val listener = object : View.OnAttachStateChangeListener {
@@ -45,7 +45,7 @@ fun View.attachEvents(): Publisher<ViewEvent> {
     }
 }
 
-fun LifecycleOwner.asPublisher(): Publisher<Lifecycle.Event> {
+internal fun LifecycleOwner.asPublisher(): Publisher<Lifecycle.Event> {
     return Publisher { subscriber ->
         var requested = false
         val observer = GenericLifecycleObserver { _, event -> subscriber.onNext(event) }
@@ -68,7 +68,7 @@ fun LifecycleOwner.asPublisher(): Publisher<Lifecycle.Event> {
 /**
  * Returns a [Publisher] that is unsubscribed from [this] when the given [View] is detached.
  */
-fun <T> Publisher<T>.androidLifecycleDispose(view: View): Publisher<T> {
+internal fun <T> Publisher<T>.androidLifecycleDispose(view: View): Publisher<T> {
     return this.takeUntil(
         view.attachEvents().filter { it is ViewEvent.Detach }
     )
@@ -78,7 +78,7 @@ fun <T> Publisher<T>.androidLifecycleDispose(view: View): Publisher<T> {
  * Returns a [Publisher] that is unsubscribed from [this] when the given [LifecycleOwner] (Fragment
  * or Activity) goes out-of-lifecycle.
  */
-fun <T> Publisher<T>.androidLifecycleDispose(lifecycleOwner: LifecycleOwner): Publisher<T> {
+internal fun <T> Publisher<T>.androidLifecycleDispose(lifecycleOwner: LifecycleOwner): Publisher<T> {
     return this.takeUntil(
         lifecycleOwner.asPublisher().filter { it == Lifecycle.Event.ON_DESTROY }
     )

--- a/sdk/src/main/kotlin/io/rover/sdk/streams/Publishers.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/streams/Publishers.kt
@@ -8,7 +8,7 @@ import org.reactivestreams.Subscription
  * These methods create a new [Publisher] from scratch.  Often used as the root of a publisher
  * chain.
  */
-object Publishers {
+internal object Publishers {
     fun <T> just(item: T): Publisher<T> {
         return Publisher { subscriber ->
             var completed = false

--- a/sdk/src/main/kotlin/io/rover/sdk/streams/Schedulers.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/streams/Schedulers.kt
@@ -9,7 +9,7 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import java.util.concurrent.Executor
 
-interface Scheduler {
+internal interface Scheduler {
     fun execute(runnable: () -> Unit)
 
     companion object
@@ -18,7 +18,7 @@ interface Scheduler {
 /**
  * Generate a [Scheduler] for the Android main thread/looper.
  */
-fun Scheduler.Companion.forAndroidMainThread(): Scheduler {
+internal fun Scheduler.Companion.forAndroidMainThread(): Scheduler {
     val handler = Handler(Looper.getMainLooper())
     return object : Scheduler {
         override fun execute(runnable: () -> Unit) {
@@ -27,7 +27,7 @@ fun Scheduler.Companion.forAndroidMainThread(): Scheduler {
     }
 }
 
-fun Scheduler.Companion.forExecutor(executor: Executor): Scheduler {
+internal fun Scheduler.Companion.forExecutor(executor: Executor): Scheduler {
     return object : Scheduler {
         override fun execute(runnable: () -> Unit) {
             executor.execute(runnable)
@@ -35,7 +35,7 @@ fun Scheduler.Companion.forExecutor(executor: Executor): Scheduler {
     }
 }
 
-fun <T> Publisher<T>.observeOn(scheduler: Scheduler): Publisher<T> {
+internal fun <T> Publisher<T>.observeOn(scheduler: Scheduler): Publisher<T> {
     return Publisher { subscriber ->
         this@observeOn.subscribe(object : Subscriber<T> {
             override fun onComplete() {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/BackgroundImageConfiguration.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/BackgroundImageConfiguration.kt
@@ -9,7 +9,7 @@ import android.graphics.Shader
  * The method these are specified with is a bit idiosyncratic on account of Android implementation
  * details and the combination of Drawables the view uses to achieve the effect.
  */
-class BackgroundImageConfiguration(
+internal class BackgroundImageConfiguration(
     /**
      * Bounds in pixels, in *relative insets from their respective edges*.
      *

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/Extensions.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/Extensions.kt
@@ -12,11 +12,11 @@ import io.rover.sdk.data.domain.Color
  * See "Converting DP Units to Pixel Units" on
  * https://developer.android.com/guide/practices/screens_support.html
  */
-fun Float.dpAsPx(displayMetrics: DisplayMetrics): Int {
+internal fun Float.dpAsPx(displayMetrics: DisplayMetrics): Int {
     return this.dpAsPx(displayMetrics.density)
 }
 
-fun Float.dpAsPx(displayDensity: Float): Int {
+internal fun Float.dpAsPx(displayDensity: Float): Int {
     // TODO change to: TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, this, metrics)
     return (this * displayDensity + 0.5f).toInt()
 }
@@ -26,20 +26,20 @@ fun Float.dpAsPx(displayDensity: Float): Int {
  *
  * See [Converting DP Units to Pixel Units](https://developer.android.com/guide/practices/screens_support.html)
  */
-fun Int.dpAsPx(displayMetrics: DisplayMetrics): Int {
+internal fun Int.dpAsPx(displayMetrics: DisplayMetrics): Int {
     return dpAsPx(displayMetrics.density)
 }
 
-fun Int.dpAsPx(displayDensity: Float): Int {
+internal fun Int.dpAsPx(displayDensity: Float): Int {
     // TODO change to: TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, this, metrics)
     return (this * displayDensity + 0.5f).toInt()
 }
 
-fun Int.pxAsDp(displayMetrics: DisplayMetrics): Float {
+internal fun Int.pxAsDp(displayMetrics: DisplayMetrics): Float {
     return pxAsDp(displayMetrics.density)
 }
 
-fun Int.pxAsDp(displayDensity: Float): Float {
+internal fun Int.pxAsDp(displayDensity: Float): Float {
     return this / displayDensity
 }
 
@@ -49,7 +49,7 @@ fun Int.pxAsDp(displayDensity: Float): Float {
  * See "Converting DP Units to Pixel Units" on
  * https://developer.android.com/guide/practices/screens_support.html
  */
-fun RectF.dpAsPx(displayMetrics: DisplayMetrics): Rect {
+internal fun RectF.dpAsPx(displayMetrics: DisplayMetrics): Rect {
     return Rect(
         left.dpAsPx(displayMetrics),
         top.dpAsPx(displayMetrics),
@@ -58,11 +58,11 @@ fun RectF.dpAsPx(displayMetrics: DisplayMetrics): Rect {
     )
 }
 
-fun Color.asAndroidColor(): Int {
+internal fun Color.asAndroidColor(): Int {
     return (alpha * 255).toInt() shl 24 or (red shl 16) or (green shl 8) or blue
 }
 
-fun RectF.toMeasuredSize(density: Float): MeasuredSize {
+internal fun RectF.toMeasuredSize(density: Float): MeasuredSize {
     return MeasuredSize(
         width(),
         height(),

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/Interfaces.kt
@@ -2,6 +2,7 @@ package io.rover.sdk.ui
 
 import android.os.Parcelable
 import android.view.WindowManager
+import io.rover.sdk.data.domain.Experience
 import io.rover.sdk.ui.navigation.ExperienceExternalNavigationEvent
 import io.rover.sdk.ui.navigation.NavigationViewModelInterface
 import io.rover.sdk.ui.toolbar.ExperienceToolbarViewModelInterface
@@ -13,7 +14,7 @@ import org.reactivestreams.Publisher
  * Responsible for fetching and displaying an Experience, with the appropriate Android toolbar along
  * the top.
  */
-interface RoverViewModelInterface : BindableViewModel {
+internal interface RoverViewModelInterface : BindableViewModel {
     /**
      * Emits view models that should be bound to the toolbar (which itself should be a
      * [ViewExperienceToolbar]).

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/PixelSize.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/PixelSize.kt
@@ -8,7 +8,7 @@ import android.util.Size
  * Rather equivalent to Android 21's [Size], which is not available on Android 18 and does not
  * implement [Comparable] at any rate.
  */
-data class PixelSize(val width: Int, val height: Int) : Comparable<PixelSize> {
+internal data class PixelSize(val width: Int, val height: Int) : Comparable<PixelSize> {
     override fun compareTo(other: PixelSize): Int {
         // what constitutes a smaller size? pixel count, naturally.
         val totalPixels = width * height

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/Rect.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/Rect.kt
@@ -23,7 +23,7 @@ package io.rover.sdk.ui
  * Somewhat equivalent to [android.graphics.Rect], but immutable and decoupled from the Android
  * API.
  */
-data class Rect(
+internal data class Rect(
     val left: Int,
     val top: Int,
     val right: Int,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/RectF.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/RectF.kt
@@ -6,7 +6,7 @@ package io.rover.sdk.ui
  * Somewhat equivalent to [android.graphics.RectF], but immutable and decoupled from the Android
  * API.
  */
-data class RectF(
+internal data class RectF(
     val left: Float,
     val top: Float,
     val right: Float,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/RoverView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/RoverView.kt
@@ -49,12 +49,12 @@ import org.reactivestreams.Publisher
  *
  * See [RoverActivity] for an example of how to integrate.
  */
-internal class RoverView : CoordinatorLayout {
+internal class RoverView : CoordinatorLayout, MeasuredBindableView<RoverViewModelInterface> {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
-    var viewModelBinding: MeasuredBindableView.Binding<RoverViewModelInterface>? by ViewModelBinding(false) { binding, subscriptionCallback ->
+    override var viewModelBinding: MeasuredBindableView.Binding<RoverViewModelInterface>? by ViewModelBinding(false) { binding, subscriptionCallback ->
         // sadly have to set rebindingAllowed to be false because of complexity dealing with the
         // toolbar; the toolbar may not be configured twice.
         val viewModel = binding?.viewModel

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/RoverView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/RoverView.kt
@@ -49,12 +49,12 @@ import org.reactivestreams.Publisher
  *
  * See [RoverActivity] for an example of how to integrate.
  */
-class RoverView : CoordinatorLayout, MeasuredBindableView<RoverViewModelInterface> {
+internal class RoverView : CoordinatorLayout {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
-    override var viewModelBinding: MeasuredBindableView.Binding<RoverViewModelInterface>? by ViewModelBinding(false) { binding, subscriptionCallback ->
+    var viewModelBinding: MeasuredBindableView.Binding<RoverViewModelInterface>? by ViewModelBinding(false) { binding, subscriptionCallback ->
         // sadly have to set rebindingAllowed to be false because of complexity dealing with the
         // toolbar; the toolbar may not be configured twice.
         val viewModel = binding?.viewModel
@@ -144,19 +144,14 @@ class RoverView : CoordinatorLayout, MeasuredBindableView<RoverViewModelInterfac
         }
     }
 
-    override fun onAttachedToWindow() {
-        super.onAttachedToWindow()
-
-    }
-
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         toolbarHost = null
     }
 
-    protected var progressIndicatorView: View? = null
+    private var progressIndicatorView: View? = null
 
-    protected fun setUpProgressIndicator() {
+    private fun setUpProgressIndicator() {
         val drawable = CircularProgressDrawable(context)
         drawable.start()
         val imageView = AppCompatImageView(
@@ -173,11 +168,11 @@ class RoverView : CoordinatorLayout, MeasuredBindableView<RoverViewModelInterfac
         }
     }
 
-    protected fun turnOnProgressIndicator() {
+    private fun turnOnProgressIndicator() {
         progressIndicatorView?.visibility = View.VISIBLE
     }
 
-    protected fun turnOffProgressIndicator() {
+    private fun turnOffProgressIndicator() {
         progressIndicatorView?.visibility = View.GONE
     }
 

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/RoverViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/RoverViewModel.kt
@@ -76,8 +76,6 @@ internal class RoverViewModel(
                 is ExperienceRequest.ById -> FetchExperienceRequest.ExperienceQueryIdentifier.ById(experienceRequest.experienceId)
             }).observeOn(mainThreadScheduler)
 
-
-
     /**
      * Hold on to a reference to the navigation view model so that it can contribute to the Android
      * state restore parcelable.

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/RoverViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/RoverViewModel.kt
@@ -25,7 +25,7 @@ import io.rover.sdk.ui.toolbar.ToolbarConfiguration
 import kotlinx.android.parcel.Parcelize
 import org.reactivestreams.Publisher
 
-class RoverViewModel(
+open class RoverViewModel(
     private val experienceRequest: ExperienceRequest,
     private val graphQlApiService: GraphQlApiService,
     private val mainThreadScheduler: Scheduler,
@@ -33,6 +33,13 @@ class RoverViewModel(
     private val resolveNavigationViewModel: (experience: Experience, icicle: Parcelable?) -> NavigationViewModelInterface,
     private val icicle: Parcelable? = null
 ) : RoverViewModelInterface {
+
+    /**
+     * Override this method to allow you to modify the experience before it is displayed.
+     */
+    open fun transformExperience(experience: Experience): Experience {
+        return experience
+    }
 
     override val state: Parcelable
         get() {
@@ -76,6 +83,8 @@ class RoverViewModel(
                 is ExperienceRequest.ByCampaignUrl -> FetchExperienceRequest.ExperienceQueryIdentifier.ByUniversalLink(experienceRequest.url)
                 is ExperienceRequest.ById -> FetchExperienceRequest.ExperienceQueryIdentifier.ById(experienceRequest.experienceId)
             }).observeOn(mainThreadScheduler)
+
+
 
     /**
      * Hold on to a reference to the navigation view model so that it can contribute to the Android
@@ -147,7 +156,9 @@ class RoverViewModel(
                    ))
                }
                is ApiResult.Success -> {
-                   experiences.onNext(networkResult.response)
+                   experiences.onNext(
+                       transformExperience(networkResult.response)
+                   )
                }
            }
         }

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/RoverViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/RoverViewModel.kt
@@ -25,21 +25,13 @@ import io.rover.sdk.ui.toolbar.ToolbarConfiguration
 import kotlinx.android.parcel.Parcelize
 import org.reactivestreams.Publisher
 
-open class RoverViewModel(
+internal class RoverViewModel(
     private val experienceRequest: ExperienceRequest,
     private val graphQlApiService: GraphQlApiService,
     private val mainThreadScheduler: Scheduler,
-    private val sessionTracker: SessionTracker,
     private val resolveNavigationViewModel: (experience: Experience, icicle: Parcelable?) -> NavigationViewModelInterface,
     private val icicle: Parcelable? = null
 ) : RoverViewModelInterface {
-
-    /**
-     * Override this method to allow you to modify the experience before it is displayed.
-     */
-    open fun transformExperience(experience: Experience): Experience {
-        return experience
-    }
 
     override val state: Parcelable
         get() {
@@ -156,9 +148,7 @@ open class RoverViewModel(
                    ))
                }
                is ApiResult.Success -> {
-                   experiences.onNext(
-                       transformExperience(networkResult.response)
-                   )
+                   experiences.onNext(networkResult.response)
                }
            }
         }

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/barcode/BarcodeBlockView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/barcode/BarcodeBlockView.kt
@@ -11,7 +11,7 @@ import io.rover.sdk.ui.blocks.concerns.ViewComposition
 import io.rover.sdk.ui.blocks.concerns.layout.LayoutableView
 import io.rover.sdk.ui.blocks.concerns.layout.ViewBlock
 
-class BarcodeBlockView : AppCompatImageView, LayoutableView<BarcodeBlockViewModelInterface> {
+internal class BarcodeBlockView : AppCompatImageView, LayoutableView<BarcodeBlockViewModelInterface> {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/barcode/BarcodeBlockViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/barcode/BarcodeBlockViewModel.kt
@@ -3,7 +3,7 @@ package io.rover.sdk.ui.blocks.barcode
 import io.rover.sdk.ui.blocks.concerns.layout.BlockViewModelInterface
 import io.rover.sdk.ui.layout.ViewType
 
-class BarcodeBlockViewModel(
+internal class BarcodeBlockViewModel(
     private val blockViewModel: BlockViewModelInterface,
     private val barcodeViewModel: BarcodeViewModelInterface
 ) : BarcodeBlockViewModelInterface,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/barcode/BarcodeViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/barcode/BarcodeViewModel.kt
@@ -8,7 +8,7 @@ import io.rover.sdk.ui.RectF
 /**
  * Barcode display view model.
  */
-class BarcodeViewModel(
+internal class BarcodeViewModel(
     private val barcode: Barcode,
     private val measurementService: MeasurementService
 ) : BarcodeViewModelInterface {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/barcode/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/barcode/Interfaces.kt
@@ -7,9 +7,9 @@ import io.rover.sdk.ui.blocks.concerns.layout.Measurable
 import io.rover.sdk.ui.concerns.BindableViewModel
 import io.rover.sdk.ui.concerns.MeasuredBindableView
 
-interface ViewBarcodeInterface : MeasuredBindableView<BarcodeViewModelInterface>
+internal interface ViewBarcodeInterface : MeasuredBindableView<BarcodeViewModelInterface>
 
-interface BarcodeViewModelInterface : Measurable, BindableViewModel {
+internal interface BarcodeViewModelInterface : Measurable, BindableViewModel {
     val barcodeType: BarcodeType
 
     val barcodeValue: String
@@ -19,7 +19,7 @@ interface BarcodeViewModelInterface : Measurable, BindableViewModel {
     }
 }
 
-interface BarcodeBlockViewModelInterface :
+internal interface BarcodeBlockViewModelInterface :
     CompositeBlockViewModelInterface,
     LayoutableViewModel,
     BlockViewModelInterface,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/barcode/ViewBarcode.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/barcode/ViewBarcode.kt
@@ -12,7 +12,7 @@ import io.rover.sdk.ui.concerns.ViewModelBinding
  * Mixin that binds a barcode view model to an [AppCompatImageView] by rendering the barcodes and
  * displaying them in the image view.
  */
-class ViewBarcode(
+internal class ViewBarcode(
     private val barcodeView: AppCompatImageView
 ) : ViewBarcodeInterface {
     init {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/button/ButtonBlockView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/button/ButtonBlockView.kt
@@ -22,7 +22,7 @@ import io.rover.sdk.ui.blocks.concerns.text.ViewText
 // to pick up.
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 @SuppressLint("NewApi")
-class ButtonBlockView : AppCompatTextView, LayoutableView<ButtonBlockViewModelInterface> {
+internal class ButtonBlockView : AppCompatTextView, LayoutableView<ButtonBlockViewModelInterface> {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/button/ButtonBlockViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/button/ButtonBlockViewModel.kt
@@ -6,7 +6,7 @@ import io.rover.sdk.ui.layout.ViewType
 import io.rover.sdk.ui.blocks.concerns.layout.BlockViewModelInterface
 import io.rover.sdk.ui.blocks.concerns.text.TextViewModelInterface
 
-class ButtonBlockViewModel(
+internal class ButtonBlockViewModel(
     blockViewModel: BlockViewModelInterface,
     private val borderViewModel: BorderViewModelInterface,
     private val backgroundViewModel: BackgroundViewModelInterface,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/button/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/button/Interfaces.kt
@@ -15,9 +15,9 @@ import io.rover.sdk.ui.concerns.BindableViewModel
  * Note that if you're looking for the Click event/handling itself, that is handled in
  * [BlockViewModel].
  */
-interface ButtonViewModelInterface : BindableViewModel
+internal interface ButtonViewModelInterface : BindableViewModel
 
-interface ButtonBlockViewModelInterface :
+internal interface ButtonBlockViewModelInterface :
     CompositeBlockViewModelInterface,
     LayoutableViewModel,
     BlockViewModelInterface,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/ViewComposition.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/ViewComposition.kt
@@ -8,7 +8,7 @@ import android.view.View
  * changes that are only exposed by Android with a template pattern and not a callback registration
  * pattern.
  */
-class ViewComposition : ViewCompositionInterface {
+internal class ViewComposition : ViewCompositionInterface {
     private val beforeDraws: MutableList<(Canvas) -> Unit> = mutableListOf()
     private val afterDraws: MutableList<(Canvas) -> Unit> = mutableListOf()
     private val onSizeChangedCallbacks: MutableList<(width: Int, height: Int, oldWidth: Int, oldHeight: Int) -> Unit> = mutableListOf()

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/background/BackgroundViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/background/BackgroundViewModel.kt
@@ -21,7 +21,7 @@ import io.rover.sdk.ui.dpAsPx
 import org.reactivestreams.Publisher
 import java.util.concurrent.TimeUnit
 
-class BackgroundViewModel(
+internal class BackgroundViewModel(
     private val background: Background,
     private val assetService: AssetService,
     private val imageOptimizationService: ImageOptimizationService,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/background/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/background/Interfaces.kt
@@ -14,13 +14,13 @@ import io.rover.sdk.ui.concerns.PrefetchAfterMeasure
  *
  * Backgrounds can specify a background colour or image.
  */
-interface ViewBackgroundInterface : MeasuredBindableView<BackgroundViewModelInterface>
+internal interface ViewBackgroundInterface : MeasuredBindableView<BackgroundViewModelInterface>
 
 /**
  * This interface is exposed by View Models that have support for a background.  Equivalent to
  * the [Background] domain model interface.
  */
-interface BackgroundViewModelInterface : BindableViewModel, PrefetchAfterMeasure {
+internal interface BackgroundViewModelInterface : BindableViewModel, PrefetchAfterMeasure {
     val backgroundColor: Int
 
     /**

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/background/ViewBackground.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/background/ViewBackground.kt
@@ -14,7 +14,7 @@ import io.rover.sdk.platform.DrawableWrapper
 import io.rover.sdk.ui.concerns.ViewModelBinding
 import io.rover.sdk.ui.concerns.MeasuredBindableView
 
-class ViewBackground(
+internal class ViewBackground(
     override val view: View
 ) : ViewBackgroundInterface {
     private val shortAnimationDuration = view.resources.getInteger(
@@ -86,7 +86,7 @@ class ViewBackground(
     }
 }
 
-class BackgroundColorDrawableWrapper(
+internal class BackgroundColorDrawableWrapper(
     private val backgroundColor: Int,
     private val drawableOnTopOfColor: Drawable
 ) : DrawableWrapper(drawableOnTopOfColor) {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/border/BorderViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/border/BorderViewModel.kt
@@ -3,7 +3,7 @@ package io.rover.sdk.ui.blocks.concerns.border
 import io.rover.sdk.data.domain.Border
 import io.rover.sdk.ui.asAndroidColor
 
-class BorderViewModel(
+internal class BorderViewModel(
     val border: Border
 ) : BorderViewModelInterface {
     override val borderColor: Int

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/border/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/border/Interfaces.kt
@@ -9,13 +9,13 @@ import io.rover.sdk.ui.concerns.BindableViewModel
  *
  * Borders can specify a border of arbitrary width, with optional rounded corners.
  */
-interface ViewBorderInterface : MeasuredBindableView<BorderViewModelInterface>
+internal interface ViewBorderInterface : MeasuredBindableView<BorderViewModelInterface>
 
 /**
  * This interface is exposed by View Models that have support for a border (of arbitrary width and
  * possibly rounded with a radius).  Equivalent to the [Border] domain model interface.
  */
-interface BorderViewModelInterface : BindableViewModel {
+internal interface BorderViewModelInterface : BindableViewModel {
     /**
      * An Android color ARGB int of the border color.
      */

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/border/ViewBorder.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/border/ViewBorder.kt
@@ -15,7 +15,7 @@ import io.rover.sdk.ui.concerns.ViewModelBinding
 import io.rover.sdk.ui.dpAsPx
 import io.rover.sdk.ui.blocks.concerns.ViewCompositionInterface
 
-class ViewBorder(
+internal class ViewBorder(
     override val view: View,
     viewComposition: ViewCompositionInterface
 ) : ViewBorderInterface {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/BlockViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/BlockViewModel.kt
@@ -19,7 +19,7 @@ import io.rover.sdk.platform.whenNotNull
  * - LayoutableViewModel probably needs to split, because we want to be able to delegate the frame()
  *   method to the new mixin version of BlockViewModel but obviously it should not specify view type
  */
-class BlockViewModel(
+internal class BlockViewModel(
     private val block: Block,
     private val paddingDeflections: Set<LayoutPaddingDeflection> = emptySet(),
     private val measurable: Measurable? = null

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/Interfaces.kt
@@ -10,7 +10,7 @@ import org.reactivestreams.Publisher
  *
  * This is responsible for setting padding and anything else relating to block layout.
  */
-interface ViewBlockInterface : MeasuredBindableView<BlockViewModelInterface>
+internal interface ViewBlockInterface : MeasuredBindableView<BlockViewModelInterface>
 
 /**
  * Exposed by a view model that may need to contribute to the Android view padding around the
@@ -23,14 +23,14 @@ interface ViewBlockInterface : MeasuredBindableView<BlockViewModelInterface>
  * Note that this should not be added to a view model's interface; it that is done it will be mixed
  * into any surrounding view block, where it is not used and will be misleading.
  */
-interface LayoutPaddingDeflection {
+internal interface LayoutPaddingDeflection {
     val paddingDeflection: Padding
 }
 
 /**
  * Padding values surrounding a rectilinear UI item, in dp.
  */
-data class Padding(
+internal data class Padding(
     val left: Int,
     val top: Int,
     val right: Int,
@@ -49,7 +49,7 @@ data class Padding(
 /**
  * Can vertically measure its content for stacked/autoheight purposes.
  */
-interface Measurable {
+internal interface Measurable {
     /**
      * Measure the "natural" height for the content contained in this block (for
      * example, a wrapped block of text will consume up to some height depending on content and
@@ -65,13 +65,13 @@ interface Measurable {
  * level concerns shared by all blocks, but has its own mixin implementation -- BlockViewModel --
  * that would cause an ambiguity a category for the fully block objects themselves.
   */
-interface CompositeBlockViewModelInterface : BlockViewModelInterface
+internal interface CompositeBlockViewModelInterface : BlockViewModelInterface
 
 /**
  * A view model for Blocks (particularly, the dynamic layout concerns thereof) that can
  * be laid out in a Rover experience.
  */
-interface BlockViewModelInterface : LayoutableViewModel {
+internal interface BlockViewModelInterface : LayoutableViewModel {
 
     /**
      * The full amount contributed by this block (including its own height and offsets) to the

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/LayoutableView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/LayoutableView.kt
@@ -11,4 +11,4 @@ import io.rover.sdk.ui.concerns.MeasuredBindableView
  * interface rather than an abstract [View] subclass in order to allow implementers to inherit from
  * various different [View] subclasses.
  */
-interface LayoutableView<VM : LayoutableViewModel> : MeasuredBindableView<VM>
+internal interface LayoutableView<VM : LayoutableViewModel> : MeasuredBindableView<VM>

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/LayoutableViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/LayoutableViewModel.kt
@@ -15,7 +15,7 @@ import io.rover.sdk.ui.Rect
  * (View models that do not implement this interface are typically used in a compositional way
  * as a part of other view models that do implement [LayoutableViewModel].
  */
-interface LayoutableViewModel : BindableViewModel {
+internal interface LayoutableViewModel : BindableViewModel {
     /**
      * Measures and returns a [RectF] of the placement the view model (with origin being the
      * bounds).

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/ViewBlock.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/ViewBlock.kt
@@ -6,7 +6,7 @@ import io.rover.sdk.ui.concerns.MeasuredBindableView
 import io.rover.sdk.ui.concerns.ViewModelBinding
 import io.rover.sdk.ui.dpAsPx
 
-class ViewBlock(
+internal class ViewBlock(
     override val view: View
 ) : ViewBlockInterface {
     override var viewModelBinding: MeasuredBindableView.Binding<BlockViewModelInterface>? by ViewModelBinding { binding, _ ->

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/AndroidRichTextToSpannedTransformer.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/AndroidRichTextToSpannedTransformer.kt
@@ -5,7 +5,7 @@ import android.text.Spanned
 import android.text.style.StyleSpan
 import io.rover.sdk.platform.roverTextHtmlAsSpanned
 
-class AndroidRichTextToSpannedTransformer : RichTextToSpannedTransformer {
+internal class AndroidRichTextToSpannedTransformer : RichTextToSpannedTransformer {
     override fun transform(string: String, boldRelativeToBlockWeight: Font): Spanned {
         val spanned = string.roverTextHtmlAsSpanned()
 

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/Font.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/Font.kt
@@ -5,7 +5,7 @@ import android.graphics.Typeface
 /**
  * A specific font in the font-family and style tuple appropriate for Android.
  */
-data class Font(
+internal data class Font(
     /**
      * A font family name.
      */

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/FontAppearance.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/FontAppearance.kt
@@ -5,7 +5,7 @@ import android.graphics.Paint
 /**
  * A selected [Font] with a size, colour, and alignment to be drawn.
  */
-data class FontAppearance(
+internal data class FontAppearance(
     /**
      * Font size, in Android Scalable Pixels.
      */

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/Interfaces.kt
@@ -6,13 +6,13 @@ import io.rover.sdk.ui.blocks.text.TextBlockViewModel
 import io.rover.sdk.ui.concerns.MeasuredBindableView
 import io.rover.sdk.ui.concerns.BindableViewModel
 
-interface ViewTextInterface : MeasuredBindableView<TextViewModelInterface>
+internal interface ViewTextInterface : MeasuredBindableView<TextViewModelInterface>
 
 /**
  * View Model for block content that contains rich text content (decorated with strong, italic, and
  * underline HTML tags).
  */
-interface TextViewModelInterface : Measurable, BindableViewModel {
+internal interface TextViewModelInterface : Measurable, BindableViewModel {
     val text: String
 
     val singleLine: Boolean
@@ -33,6 +33,6 @@ interface TextViewModelInterface : Measurable, BindableViewModel {
  * This logic is kept outside of the [TextBlockViewModel] because it has runtime Android
  * dependencies.
  */
-interface RichTextToSpannedTransformer {
+internal interface RichTextToSpannedTransformer {
     fun transform(string: String, boldRelativeToBlockWeight: Font): Spanned
 }

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/TextViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/TextViewModel.kt
@@ -13,7 +13,7 @@ import io.rover.sdk.ui.asAndroidColor
 /**
  * Text styling and size concerns.
  */
-class TextViewModel(
+internal class TextViewModel(
     private val styledText: Text,
     private val measurementService: MeasurementService,
     override val singleLine: Boolean = false,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/TypefaceAndExplicitBoldSpan.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/TypefaceAndExplicitBoldSpan.kt
@@ -13,7 +13,7 @@ import io.rover.sdk.logging.log
  * this one instead allows you to specify it explicitly.  It will honour existing italic paint
  * style, but it always overrides the bold setting.
  */
-class TypefaceAndExplicitBoldSpan(
+internal class TypefaceAndExplicitBoldSpan(
     private val fontFamily: String,
     private val fontStyle: Int
 ) : TypefaceSpan(fontFamily) {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/ViewText.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/text/ViewText.kt
@@ -12,7 +12,7 @@ import io.rover.sdk.ui.concerns.ViewModelBinding
 /**
  * Mixin that binds a text block view model to the relevant parts of a [TextView].
  */
-class ViewText(
+internal class ViewText(
     private val textView: TextView,
     private val textToSpannedTransformer: RichTextToSpannedTransformer
 ) : ViewTextInterface {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/ImageBlockView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/ImageBlockView.kt
@@ -14,7 +14,7 @@ import io.rover.sdk.ui.blocks.concerns.ViewComposition
 import io.rover.sdk.ui.concerns.MeasuredBindableView
 import io.rover.sdk.ui.concerns.ViewModelBinding
 
-class ImageBlockView : AppCompatImageView, LayoutableView<ImageBlockViewModelInterface> {
+internal class ImageBlockView : AppCompatImageView, LayoutableView<ImageBlockViewModelInterface> {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/ImageBlockViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/ImageBlockViewModel.kt
@@ -6,7 +6,7 @@ import io.rover.sdk.ui.blocks.concerns.layout.BlockViewModelInterface
 import io.rover.sdk.ui.blocks.concerns.border.BorderViewModelInterface
 import io.rover.sdk.ui.concerns.MeasuredSize
 
-class ImageBlockViewModel(
+internal class ImageBlockViewModel(
     private val blockViewModel: BlockViewModelInterface,
     private val backgroundViewModel: BackgroundViewModelInterface,
     private val imageViewModel: ImageViewModelInterface,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/ImageViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/ImageViewModel.kt
@@ -24,7 +24,7 @@ import io.rover.sdk.ui.dpAsPx
 import org.reactivestreams.Publisher
 import java.util.concurrent.TimeUnit
 
-class ImageViewModel(
+internal class ImageViewModel(
     private val image: Image?,
     private val block: Block,
     private val assetService: AssetService,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/Interfaces.kt
@@ -16,9 +16,9 @@ import org.reactivestreams.Publisher
 // ViewImage mixin is binding against ImageBlockViewModelInterface instead of
 // ImageViewModelInterface in order to discover the block's opacity for use in an animation.  This
 // is a hack and should be solved properly.
-interface ViewImageInterface : MeasuredBindableView<ImageBlockViewModelInterface>
+internal interface ViewImageInterface : MeasuredBindableView<ImageBlockViewModelInterface>
 
-interface ImageViewModelInterface : Measurable, BindableViewModel, PrefetchAfterMeasure {
+internal interface ImageViewModelInterface : Measurable, BindableViewModel, PrefetchAfterMeasure {
     /**
      * Subscribe to be informed of the image becoming ready.
      */
@@ -40,13 +40,10 @@ interface ImageViewModelInterface : Measurable, BindableViewModel, PrefetchAfter
     )
 }
 
-interface ImageBlockViewModelInterface :
+internal interface ImageBlockViewModelInterface :
     CompositeBlockViewModelInterface,
     LayoutableViewModel,
     BlockViewModelInterface,
     BackgroundViewModelInterface,
     BorderViewModelInterface,
     ImageViewModelInterface
-
-@Deprecated("Use MeasuredSize passed in through the view model Binding.")
-typealias DimensionCallback = (width: Int, height: Int) -> Unit

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/ViewImage.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/ViewImage.kt
@@ -10,7 +10,7 @@ import io.rover.sdk.ui.concerns.MeasuredBindableView
 /**
  * Mixin that binds an image block view model to the relevant parts of an [ImageView].
  */
-class ViewImage(
+internal class ViewImage(
     private val imageView: AppCompatImageView
 ) : ViewImageInterface {
     private val shortAnimationDuration = imageView.resources.getInteger(

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/rectangle/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/rectangle/Interfaces.kt
@@ -10,4 +10,4 @@ import io.rover.sdk.ui.blocks.concerns.layout.LayoutableViewModel
  * View Model for a block that contains no content (other than its own border and
  * background).
  */
-interface RectangleBlockViewModelInterface : CompositeBlockViewModelInterface, LayoutableViewModel, BlockViewModelInterface, BackgroundViewModelInterface, BorderViewModelInterface
+internal interface RectangleBlockViewModelInterface : CompositeBlockViewModelInterface, LayoutableViewModel, BlockViewModelInterface, BackgroundViewModelInterface, BorderViewModelInterface

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/rectangle/RectangleBlockView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/rectangle/RectangleBlockView.kt
@@ -16,7 +16,7 @@ import io.rover.sdk.ui.blocks.concerns.border.ViewBorder
 import io.rover.sdk.ui.blocks.concerns.layout.LayoutableView
 import io.rover.sdk.ui.blocks.concerns.layout.ViewBlock
 
-class RectangleBlockView : View, LayoutableView<RectangleBlockViewModelInterface> {
+internal class RectangleBlockView : View, LayoutableView<RectangleBlockViewModelInterface> {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/rectangle/RectangleBlockViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/rectangle/RectangleBlockViewModel.kt
@@ -5,7 +5,7 @@ import io.rover.sdk.ui.blocks.concerns.background.BackgroundViewModelInterface
 import io.rover.sdk.ui.blocks.concerns.layout.BlockViewModelInterface
 import io.rover.sdk.ui.blocks.concerns.border.BorderViewModelInterface
 
-class RectangleBlockViewModel(
+internal class RectangleBlockViewModel(
     blockViewModel: BlockViewModelInterface,
     backgroundViewModel: BackgroundViewModelInterface,
     borderViewModel: BorderViewModelInterface

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/text/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/text/Interfaces.kt
@@ -11,7 +11,7 @@ import io.rover.sdk.ui.blocks.concerns.text.TextViewModelInterface
  * View Model for a block that contains rich text content (decorated with strong, italic, and
  * underline HTML tags).
  */
-interface TextBlockViewModelInterface :
+internal interface TextBlockViewModelInterface :
     CompositeBlockViewModelInterface,
     LayoutableViewModel,
     BlockViewModelInterface,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/text/TextBlockView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/text/TextBlockView.kt
@@ -16,7 +16,7 @@ import io.rover.sdk.ui.blocks.concerns.ViewComposition
 import io.rover.sdk.ui.concerns.MeasuredBindableView
 import io.rover.sdk.ui.concerns.ViewModelBinding
 
-class TextBlockView : AppCompatTextView, LayoutableView<TextBlockViewModelInterface> {
+internal class TextBlockView : AppCompatTextView, LayoutableView<TextBlockViewModelInterface> {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/text/TextBlockViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/text/TextBlockViewModel.kt
@@ -6,7 +6,7 @@ import io.rover.sdk.ui.blocks.concerns.layout.BlockViewModelInterface
 import io.rover.sdk.ui.blocks.concerns.border.BorderViewModelInterface
 import io.rover.sdk.ui.blocks.concerns.text.TextViewModelInterface
 
-class TextBlockViewModel(
+internal class TextBlockViewModel(
     private val blockViewModel: BlockViewModelInterface,
     private val textViewModel: TextViewModelInterface,
     private val backgroundViewModel: BackgroundViewModelInterface,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/web/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/web/Interfaces.kt
@@ -9,14 +9,14 @@ import io.rover.sdk.ui.concerns.MeasuredBindableView
 import io.rover.sdk.ui.concerns.BindableViewModel
 import java.net.URL
 
-interface ViewWebInterface : MeasuredBindableView<WebViewModelInterface>
+internal interface ViewWebInterface : MeasuredBindableView<WebViewModelInterface>
 
-interface WebViewModelInterface : BindableViewModel {
+internal interface WebViewModelInterface : BindableViewModel {
     val url: URL
     val scrollingEnabled: Boolean
 }
 
-interface WebViewBlockViewModelInterface :
+internal interface WebViewBlockViewModelInterface :
     CompositeBlockViewModelInterface,
     LayoutableViewModel,
     BlockViewModelInterface,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/web/ViewWeb.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/web/ViewWeb.kt
@@ -7,7 +7,7 @@ import io.rover.sdk.ui.concerns.MeasuredBindableView
 import io.rover.sdk.ui.concerns.ViewModelBinding
 
 @SuppressLint("SetJavaScriptEnabled")
-class ViewWeb(
+internal class ViewWeb(
     private val webView: WebView
 ) : ViewWebInterface {
 

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/web/WebBlockView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/web/WebBlockView.kt
@@ -17,7 +17,7 @@ import io.rover.sdk.ui.blocks.concerns.ViewComposition
 import io.rover.sdk.ui.concerns.MeasuredBindableView
 import io.rover.sdk.ui.concerns.ViewModelBinding
 
-class WebBlockView : WebView, LayoutableView<WebViewBlockViewModelInterface> {
+internal class WebBlockView : WebView, LayoutableView<WebViewBlockViewModelInterface> {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/web/WebViewBlockViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/web/WebViewBlockViewModel.kt
@@ -5,7 +5,7 @@ import io.rover.sdk.ui.blocks.concerns.background.BackgroundViewModelInterface
 import io.rover.sdk.ui.blocks.concerns.layout.BlockViewModelInterface
 import io.rover.sdk.ui.blocks.concerns.border.BorderViewModelInterface
 
-class WebViewBlockViewModel(
+internal class WebViewBlockViewModel(
     private val blockViewModel: BlockViewModelInterface,
     private val backgroundViewModel: BackgroundViewModelInterface,
     private val borderViewModel: BorderViewModelInterface,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/web/WebViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/web/WebViewModel.kt
@@ -3,7 +3,7 @@ package io.rover.sdk.ui.blocks.web
 import io.rover.sdk.data.domain.WebView
 import java.net.URL
 
-class WebViewModel(
+internal class WebViewModel(
     private val webView: WebView
 ) : WebViewModelInterface {
 

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/concerns/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/concerns/Interfaces.kt
@@ -12,7 +12,7 @@ interface BindableViewModel
  * of what their measured size is, so they can perhaps do some sort of asynchronous background
  * update behaviour.
  */
-interface PrefetchAfterMeasure {
+internal interface PrefetchAfterMeasure {
     fun measuredSizeReadyForPrefetch(
         measuredSize: MeasuredSize
     )

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/concerns/ViewModelBinding.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/concerns/ViewModelBinding.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.KProperty
  * will provide you with a callback you can call for whenever a subscription for a subscriber you
  * created becomes ready.
  */
-class ViewModelBinding<VM : Any>(
+internal class ViewModelBinding<VM : Any>(
     private val rebindingAllowed: Boolean = true,
     private val binding: (viewModel: VM?, subscriptionCallback: (Subscription) -> Unit) -> Unit
 ) {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/containers/ActivityToolbarHost.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/containers/ActivityToolbarHost.kt
@@ -22,7 +22,7 @@ import org.reactivestreams.Publisher
  *
  * TODO: include direction about either setting the ActionBar feature to off in code or by style.
  */
-class ActivityToolbarHost(private val activity: AppCompatActivity) : RoverView.ToolbarHost {
+internal class ActivityToolbarHost(private val activity: AppCompatActivity) : RoverView.ToolbarHost {
     var menu: Menu? = null
         set(newMenu) {
             field = newMenu

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/containers/RoverActivity.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/containers/RoverActivity.kt
@@ -30,11 +30,11 @@ import io.rover.sdk.ui.navigation.ExperienceExternalNavigationEvent
  * a Rover [RoverView] in your own Activities.
  */
 open class RoverActivity : AppCompatActivity() {
-    protected open val experienceId: String? by lazy { this.intent.getStringExtra("EXPERIENCE_ID") }
+    private val experienceId: String? by lazy { this.intent.getStringExtra("EXPERIENCE_ID") }
 
-    protected open val experienceUrl: String? by lazy { this.intent.getStringExtra("EXPERIENCE_URL") }
+    private val experienceUrl: String? by lazy { this.intent.getStringExtra("EXPERIENCE_URL") }
 
-    protected val campaignId: String?
+    private val campaignId: String?
         get() = this.intent.getStringExtra("CAMPAIGN_ID")
 
     /***
@@ -51,12 +51,8 @@ open class RoverActivity : AppCompatActivity() {
      * events emitted by an Experience that "break out" of the Experience's intrinsic navigation
      * flow (ie., moving back and forth amongst Screens).  The default implementation handles
      * exiting the Activity and opening up a web browser.
-     *
-     * You may override this in a subclass if you want to handle the
-     * [ExperienceExternalNavigationEvent.Custom] event you may have emitted in view model subclass,
-     * to do some other sort of external behaviour in your app, such as open a native login screen.
      */
-    protected open fun dispatchExternalNavigationEvent(externalNavigationEvent: ExperienceExternalNavigationEvent) {
+    private fun dispatchExternalNavigationEvent(externalNavigationEvent: ExperienceExternalNavigationEvent) {
         when (externalNavigationEvent) {
             is ExperienceExternalNavigationEvent.Exit -> {
                 finish()
@@ -83,9 +79,9 @@ open class RoverActivity : AppCompatActivity() {
 
     /**
      * [RoverViewModel] is responsible for describing the appearance and behaviour of the
-     * experience contents.  If you customize it, you must return your customized version here.
+     * experience contents.
      */
-    protected open val experiencesView by lazy { RoverView(this) }
+    private val experiencesView by lazy { RoverView(this) }
 
     /**
      * Holds the currently set view model, including side-effect behaviour for binding it to the
@@ -120,7 +116,7 @@ open class RoverActivity : AppCompatActivity() {
     /**
      * Provides a method for opening URIs with a Custom Chrome Tab.
      */
-    protected open val webDisplay: EmbeddedWebBrowserDisplay? by lazy {
+    private val webDisplay: EmbeddedWebBrowserDisplay? by lazy {
         val rover = Rover.shared
         if(rover == null) {
             log.w("RoverActivity cannot work unless Rover has been initialized.")
@@ -205,10 +201,7 @@ open class RoverActivity : AppCompatActivity() {
         experiencesView.toolbarHost = null
     }
 
-    /**
-     * This method If you customize it, you must return your customized version here.
-     */
-    protected open fun experienceViewModel(
+    private fun experienceViewModel(
         rover: Rover,
         experienceRequest: RoverViewModel.ExperienceRequest,
         campaignId: String?,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/BlockAndRowLayoutManager.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/BlockAndRowLayoutManager.kt
@@ -20,7 +20,7 @@ import io.rover.sdk.ui.layout.screen.ScreenViewModelInterface
  *
  * This layout manager is perhaps a bit unusual compared to the stock ones: it's driven by data.
  */
-class BlockAndRowLayoutManager(
+internal class BlockAndRowLayoutManager(
     private val layout: Layout,
     private val displayMetrics: DisplayMetrics
 ) : RecyclerView.LayoutManager() {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/BlockAndRowRecyclerAdapter.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/BlockAndRowRecyclerAdapter.kt
@@ -13,7 +13,7 @@ import io.rover.sdk.ui.blocks.concerns.layout.LayoutableViewModel
 /**
  * The RecyclerView adapter for Experience layouts.
  */
-open class BlockAndRowRecyclerAdapter(
+internal class BlockAndRowRecyclerAdapter(
     private val layout: Layout,
     private val displayMetrics: DisplayMetrics,
     private val blockViewFactory: (viewType: ViewType, context: Context) -> LayoutableView<out LayoutableViewModel>

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/DisplayItem.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/DisplayItem.kt
@@ -8,7 +8,7 @@ import io.rover.sdk.ui.RectF
  * A sequence of [LayoutableViewModel]s in two-dimensional space, with optional clips,
  * as an output of a layout pass.
  */
-data class DisplayItem(
+internal data class DisplayItem(
     /**
      * Where in absolute space (both position and dimensions) for the entire [ScreenViewModel]
      * this item should be placed.

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/Layout.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/Layout.kt
@@ -3,7 +3,7 @@ package io.rover.sdk.ui.layout
 /**
  * The output of a Rover layout pass.
  */
-data class Layout(
+internal data class Layout(
     /**
      * All of the items that must be displayed, all laid out into a coordinate space (constrained
      * by a width that was given to the rendering process that yielded this [Layout]).

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/ViewType.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/ViewType.kt
@@ -4,7 +4,7 @@ package io.rover.sdk.ui.layout
  * The set of possible types of view that can be laid out in the [BlockAndRowRecyclerAdapter].
  * This allows us to distinguish between them without relying on reflection.
  */
-enum class ViewType {
+internal enum class ViewType {
     Row,
     Rectangle,
     Text,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/row/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/row/Interfaces.kt
@@ -11,7 +11,7 @@ import org.reactivestreams.Publisher
 /**
  * View model for Rover UI blocks.
  */
-interface RowViewModelInterface : LayoutableViewModel, BackgroundViewModelInterface {
+internal interface RowViewModelInterface : LayoutableViewModel, BackgroundViewModelInterface {
     val blockViewModels: List<BlockViewModelInterface>
 
     /**

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/row/RowView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/row/RowView.kt
@@ -12,7 +12,7 @@ import io.rover.sdk.ui.blocks.concerns.layout.LayoutableView
 import io.rover.sdk.ui.concerns.MeasuredBindableView
 import io.rover.sdk.ui.concerns.ViewModelBinding
 
-class RowView : View, LayoutableView<RowViewModelInterface> {
+internal class RowView : View, LayoutableView<RowViewModelInterface> {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/row/RowViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/row/RowViewModel.kt
@@ -18,7 +18,7 @@ import io.rover.sdk.streams.flatMap
 import io.rover.sdk.streams.share
 import org.reactivestreams.Publisher
 
-class RowViewModel(
+internal class RowViewModel(
     private val row: Row,
     private val blockViewModelResolver: (block: Block) -> CompositeBlockViewModelInterface,
     private val backgroundViewModel: BackgroundViewModelInterface

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/screen/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/screen/Interfaces.kt
@@ -31,7 +31,7 @@ import org.reactivestreams.Publisher
  *
  * Primarily used by [BlockAndRowLayoutManager].
  */
-interface ScreenViewModelInterface : BindableViewModel, BackgroundViewModelInterface {
+internal interface ScreenViewModelInterface : BindableViewModel, BackgroundViewModelInterface {
     /**
      * Do the computationally expensive operation of laying out the entire graph of UI view models.
      */

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/screen/ScreenView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/screen/ScreenView.kt
@@ -22,7 +22,7 @@ import io.rover.sdk.ui.toMeasuredSize
 import org.reactivestreams.Publisher
 import java.lang.RuntimeException
 
-class ScreenView : RecyclerView, MeasuredBindableView<ScreenViewModelInterface> {
+internal class ScreenView : RecyclerView, MeasuredBindableView<ScreenViewModelInterface> {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyle: Int) : super(

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/screen/ScreenViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/screen/ScreenViewModel.kt
@@ -18,7 +18,7 @@ import io.rover.sdk.ui.layout.row.RowViewModelInterface
 import io.rover.sdk.ui.toolbar.ToolbarConfiguration
 import org.reactivestreams.Publisher
 
-class ScreenViewModel(
+internal class ScreenViewModel(
     override val screen: Screen,
     private val backgroundViewModel: BackgroundViewModelInterface,
     private val resolveRowViewModel: (row: Row) -> RowViewModelInterface

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/navigation/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/navigation/Interfaces.kt
@@ -11,7 +11,7 @@ import io.rover.sdk.ui.concerns.BindableViewModel
 import org.reactivestreams.Publisher
 import java.net.URI
 
-interface NavigationViewModelInterface : BindableViewModel {
+internal interface NavigationViewModelInterface : BindableViewModel {
     /**
      * Emits when the user should be navigated away to some other piece of content external to the
      * Experience.

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/navigation/NavigateToFromBlock.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/navigation/NavigateToFromBlock.kt
@@ -6,7 +6,7 @@ import java.net.URI
 /**
  * Should navigate to the given URL or Screen.
  */
-sealed class NavigateToFromBlock(
+internal sealed class NavigateToFromBlock(
     val block: Block
 ) {
     /**

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/navigation/NavigationView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/navigation/NavigationView.kt
@@ -22,7 +22,7 @@ import io.rover.sdk.ui.layout.screen.ScreenViewModelInterface
 /**
  * Navigation behaviour between screens of an Experience.
  */
-class NavigationView : FrameLayout, MeasuredBindableView<NavigationViewModelInterface> {
+internal class NavigationView : FrameLayout, MeasuredBindableView<NavigationViewModelInterface> {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/toolbar/ExperienceToolbarViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/toolbar/ExperienceToolbarViewModel.kt
@@ -3,7 +3,7 @@ package io.rover.sdk.ui.toolbar
 import io.rover.sdk.streams.PublishSubject
 import io.rover.sdk.streams.share
 
-class ExperienceToolbarViewModel(
+internal class ExperienceToolbarViewModel(
     override val configuration: ToolbarConfiguration
 ) : ExperienceToolbarViewModelInterface {
 

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/toolbar/Interfaces.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/toolbar/Interfaces.kt
@@ -3,7 +3,7 @@ package io.rover.sdk.ui.toolbar
 import android.support.v7.widget.Toolbar
 import org.reactivestreams.Publisher
 
-interface ViewExperienceToolbarInterface {
+internal interface ViewExperienceToolbarInterface {
     /**
      * Set the toolbar view model.  However, uncharacteristically of the other bindable view mixins,
      * this one is a method that returns a new [Toolbar] view.  This must be done because
@@ -16,7 +16,7 @@ interface ViewExperienceToolbarInterface {
     ): Toolbar
 }
 
-interface ExperienceToolbarViewModelInterface {
+internal interface ExperienceToolbarViewModelInterface {
     val toolbarEvents: Publisher<Event>
 
     val configuration: ToolbarConfiguration

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/toolbar/ToolbarConfiguration.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/toolbar/ToolbarConfiguration.kt
@@ -3,7 +3,7 @@ package io.rover.sdk.ui.toolbar
 /**
  * Tool bar configuration.  Colour overrides, text, text colour, and status bar settings.
  */
-data class ToolbarConfiguration(
+internal data class ToolbarConfiguration(
     val useExistingStyle: Boolean,
 
     val appBarText: String,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/toolbar/ViewExperienceToolbar.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/toolbar/ViewExperienceToolbar.kt
@@ -22,7 +22,7 @@ import io.rover.sdk.streams.subscribe
 import io.rover.sdk.ui.RoverView
 import org.reactivestreams.Subscription
 
-class ViewExperienceToolbar(
+internal class ViewExperienceToolbar(
     private val hostView: View,
     hostWindowForStatusBar: Window,
     private val context: Context,


### PR DESCRIPTION
## Description

Reduce the public api, mainly by labeling previously `public` Classes with the `internal` visibility modifier. The currently exposed classes should be `RoverActivity`, the `Rover` class and the `EventEmitter`. Unlike the `RoverActivity` and `Rover` class, the `EventEmitter` is not open, only the `trackedEvents` property is exposed in order to enable importers of the Rover sdk to capture events emitted. 
Explicit enabling of the `AnalyticsService` has been removed as it is now started via an `init` block. In instances where the attached visibility modifier obviously should be made `private`, it has been, although there's further opportunity to continue this process to improve the maintainability/readability of the codebase.

 