### PR TITLE
Bump gradle, AGP and kotlin versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.rover_sdk_version = '2.2.9'
     ext.rover_sdk_version_code = 3
 
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.30'
     ext.spek_version = '2.0.2'
     ext.dokka_version = '0.9.17'
 
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.4.0.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.rover_sdk_version = '2.2.9'
     ext.rover_sdk_version_code = 3
 
-    ext.kotlin_version = '1.3.30'
+    ext.kotlin_version = '1.3.31'
     ext.spek_version = '2.0.2'
     ext.dokka_version = '0.9.17'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 06 13:03:39 EST 2019
+#Mon May 13 17:42:04 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
## Description
Bump kotlin version to `1.3.31`, AGP version to `3.4.0` and gradle version to `5.4.1`.

## Issues 
There's an issue with the kotlin gradle plugin when using kotlin version 1.3.31 due to due to the plugin calling an API that will be deprecated at the end of 2019 which causes a gradle warning when syncing with gradle. This has no negative impact other than the warning itself and should be fixed in later kotlin gradle plugin versions. 

https://stackoverflow.com/questions/55646506/warning-api-variant-getpackagelibrary-is-obsolete-and-has-been-replaced-wit