### PR TITLE
Add mockito-kotlin2 to enable mocking of final classes

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -73,8 +73,6 @@ dependencies {
     implementation 'com.android.support:support-vector-drawable:27.1.1'
     implementation 'com.android.support:customtabs:27.1.1'
 
-    testImplementation 'junit:junit:4.12'
-
     // Shadow android.jar's stubbed version of JSON in tests:
     testImplementation 'org.json:json:20180130'
 
@@ -82,9 +80,7 @@ dependencies {
     testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek_version"
     testImplementation "org.spekframework.spek2:spek-runner-junit5:$spek_version"
 
-    testImplementation 'com.natpryce:hamkrest:1.4.2.0'
-    testImplementation 'org.amshove.kluent:kluent:1.30'
-    testImplementation 'org.amshove.kluent:kluent-android:1.30'
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
 
     // JUnit 5 support.  Needed for Spek.

--- a/sdk/src/main/kotlin/io/rover/sdk/assets/ImageOptimizationService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/assets/ImageOptimizationService.kt
@@ -14,7 +14,7 @@ import io.rover.sdk.ui.dpAsPx
 import java.net.URI
 import kotlin.math.roundToInt
 
-internal open class ImageOptimizationService  {
+internal class ImageOptimizationService  {
 
     private val urlOptimizationEnabled = true
 

--- a/sdk/src/main/kotlin/io/rover/sdk/data/graphql/GraphQlApiService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/graphql/GraphQlApiService.kt
@@ -17,7 +17,7 @@ import java.net.URL
 /**
  * Responsible for providing access the Rover cloud API, powered by GraphQL.
  */
-internal open class GraphQlApiService(
+internal class GraphQlApiService(
     private val endpoint: URL,
     private val accountToken: String?,
     private val httpClient: HttpClient

--- a/sdk/src/main/kotlin/io/rover/sdk/services/EventEmitter.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/EventEmitter.kt
@@ -12,7 +12,7 @@ import org.reactivestreams.Publisher
  *
  * Alternatively, you can add a [RoverEventListener] to receive event updates
  */
-open class EventEmitter {
+class EventEmitter {
     private val eventSubject = PublishSubject<RoverEvent>()
 
     val trackedEvents: Publisher<RoverEvent> by lazy { eventSubject.share() }

--- a/sdk/src/main/kotlin/io/rover/sdk/services/MeasurementService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/MeasurementService.kt
@@ -15,7 +15,7 @@ import io.rover.sdk.ui.blocks.concerns.text.RichTextToSpannedTransformer
 import io.rover.sdk.ui.dpAsPx
 import io.rover.sdk.ui.pxAsDp
 
-internal open class MeasurementService(
+internal class MeasurementService(
     private val displayMetrics: DisplayMetrics,
     private val richTextToSpannedTransformer: RichTextToSpannedTransformer,
     private val barcodeRenderingService: BarcodeRenderingService
@@ -32,7 +32,7 @@ internal open class MeasurementService(
      * Returns the height needed to accommodate the text at the given width, in dps.
      */
     @SuppressLint("NewApi")
-    open fun measureHeightNeededForRichText(
+    fun measureHeightNeededForRichText(
         richText: String,
         fontAppearance: FontAppearance,
         boldFontAppearance: Font,
@@ -102,7 +102,7 @@ internal open class MeasurementService(
      * Returns the height needed to accommodate the barcode, at the correct aspect, at the given
      * width, in dps.
      */
-    open fun measureHeightNeededForBarcode(
+    fun measureHeightNeededForBarcode(
         text: String,
         type: BarcodeViewModelInterface.BarcodeType,
         width: Float

--- a/sdk/src/main/kotlin/io/rover/sdk/services/SessionTracker.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/SessionTracker.kt
@@ -13,7 +13,7 @@ import java.util.Date
 import java.util.UUID
 import kotlin.math.max
 
-internal open class SessionTracker(
+internal class SessionTracker(
     private val eventEmitter: EventEmitter,
 
     private val sessionStore: SessionStore,

--- a/sdk/src/test/kotlin/io/rover/data/ExperienceSerializationSpec.kt
+++ b/sdk/src/test/kotlin/io/rover/data/ExperienceSerializationSpec.kt
@@ -19,10 +19,8 @@ object ExperienceSerializationSpec : Spek({
             it("should reserialize to equivalent JSON") {
                 val experienceNewJsonString = experience.encodeJson().toString(4)
 
-                val experienceNewJson = JSONObject(experienceNewJsonString)
                 JSONAssert.assertEquals(experienceSourceJsonString, experienceNewJsonString, false)
             }
         }
     }
-
 })

--- a/sdk/src/test/kotlin/io/rover/helpers/assertions.kt
+++ b/sdk/src/test/kotlin/io/rover/helpers/assertions.kt
@@ -1,0 +1,12 @@
+package io.rover.helpers
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+
+infix fun Any?.shouldEqual(theOther: Any?) = assertEquals(theOther, this)
+
+infix fun Any?.shouldBeInstanceOf(className: Class<*>) =
+    assertTrue(className.isInstance(this), "Expected $this to be an instance of $className")
+
+infix fun Long.shouldBeLessThan(theOther: Long) =
+    assertTrue(this < theOther, "Expected $this to be less than $theOther")

--- a/sdk/src/test/kotlin/io/rover/sdk/assets/ImageOptimizationServiceSpec.kt
+++ b/sdk/src/test/kotlin/io/rover/sdk/assets/ImageOptimizationServiceSpec.kt
@@ -46,8 +46,8 @@ object ImageOptimizationServiceSpec : Spek({
             val decodedParams = decodeUriParams(uri)
 
             it("it should ask imgix for a no-op scale") {
-                decodedParams["w"].shouldEqual("120")
-                decodedParams["h"].shouldEqual("100")
+                decodedParams["w"] shouldEqual "120"
+                decodedParams["h"] shouldEqual "100"
             }
         }
 
@@ -62,8 +62,8 @@ object ImageOptimizationServiceSpec : Spek({
             val decodedParams = decodeUriParams(uri)
 
             it("it should ask imgix to scale down by half") {
-                decodedParams["w"].shouldEqual("60")
-                decodedParams["h"].shouldEqual("50")
+                decodedParams["w"] shouldEqual "60"
+                decodedParams["h"] shouldEqual "50"
             }
         }
 
@@ -77,8 +77,8 @@ object ImageOptimizationServiceSpec : Spek({
             val decodedParams = decodeUriParams(uri)
 
             it("it should ask imgix to scale down") {
-                decodedParams["w"].shouldEqual("34")
-                decodedParams["h"].shouldEqual("29")
+                decodedParams["w"] shouldEqual "34"
+                decodedParams["h"] shouldEqual "29"
             }
         }
 
@@ -94,8 +94,8 @@ object ImageOptimizationServiceSpec : Spek({
             val decodedParams = decodeUriParams(uri)
 
             it("it should scale down the smaller dimension but not scale up the greater one") {
-                decodedParams["w"].shouldEqual("120")
-                decodedParams["h"].shouldEqual("90")
+                decodedParams["w"] shouldEqual "120"
+                decodedParams["h"] shouldEqual "90"
             }
         }
     }
@@ -129,19 +129,19 @@ object ImageOptimizationServiceSpec : Spek({
             val decodedParams = decodeUriParams(uri)
 
             it("asks imgix for a no-op crop") {
-                decodedParams["rect"].shouldEqual("0,0,120,100")
+                decodedParams["rect"] shouldEqual "0,0,120,100"
             }
 
             it("asks imgix for a no-op scale") {
-                decodedParams["w"].shouldEqual("120")
-                decodedParams["h"].shouldEqual("100")
+                decodedParams["w"] shouldEqual "120"
+                decodedParams["h"] shouldEqual "100"
             }
 
             it("sets exactly fitting insets") {
-                optimizedConfiguration.insets.left.shouldEqual(0)
-                optimizedConfiguration.insets.top.shouldEqual(0)
-                optimizedConfiguration.insets.right.shouldEqual(0)
-                optimizedConfiguration.insets.bottom.shouldEqual(0)
+                optimizedConfiguration.insets.left shouldEqual 0
+                optimizedConfiguration.insets.top shouldEqual 0
+                optimizedConfiguration.insets.right shouldEqual 0
+                optimizedConfiguration.insets.bottom shouldEqual 0
             }
         }
 
@@ -156,7 +156,7 @@ object ImageOptimizationServiceSpec : Spek({
 
             it("asks imgix for a no-op crop") {
                 // we wouldn't want imgix to scale up for us, that would be a waste.
-                decodedParams["rect"].shouldEqual("0,0,120,100")
+                decodedParams["rect"] shouldEqual "0,0,120,100"
             }
 
             it("asks imgix for a no-op scale") {
@@ -165,10 +165,10 @@ object ImageOptimizationServiceSpec : Spek({
             }
 
             it("sets exactly fitting insets") {
-                optimizedConfiguration.insets.left.shouldEqual(0)
-                optimizedConfiguration.insets.top.shouldEqual(0)
-                optimizedConfiguration.insets.right.shouldEqual(0)
-                optimizedConfiguration.insets.bottom.shouldEqual(0)
+                optimizedConfiguration.insets.left shouldEqual 0
+                optimizedConfiguration.insets.top shouldEqual 0
+                optimizedConfiguration.insets.right shouldEqual 0
+                optimizedConfiguration.insets.bottom shouldEqual 0
             }
         }
 
@@ -182,19 +182,19 @@ object ImageOptimizationServiceSpec : Spek({
             val decodedParams = decodeUriParams(uri)
 
             it("asks imgix for a no-op crop") {
-                decodedParams["rect"].shouldEqual("0,0,120,100")
+                decodedParams["rect"] shouldEqual "0,0,120,100"
             }
 
             it("asks imgix for a no-op scale") {
-                decodedParams["w"].shouldEqual("120")
-                decodedParams["h"].shouldEqual("100")
+                decodedParams["w"] shouldEqual "120"
+                decodedParams["h"] shouldEqual "100"
             }
 
             it("sets horizontal insets") {
-                optimizedConfiguration.insets.left.shouldEqual(10)
-                optimizedConfiguration.insets.right.shouldEqual(10)
-                optimizedConfiguration.insets.top.shouldEqual(0)
-                optimizedConfiguration.insets.bottom.shouldEqual(0)
+                optimizedConfiguration.insets.left shouldEqual 10
+                optimizedConfiguration.insets.right shouldEqual 10
+                optimizedConfiguration.insets.top shouldEqual 0
+                optimizedConfiguration.insets.bottom shouldEqual 0
             }
         }
 
@@ -209,19 +209,19 @@ object ImageOptimizationServiceSpec : Spek({
 
             it("asks imgix for a no-op crop") {
                 // we wouldn't want imgix to scale up for us, that would be a waste.
-                decodedParams["rect"].shouldEqual("0,0,120,100")
+                decodedParams["rect"] shouldEqual "0,0,120,100"
             }
 
             it("asks imgix for a no-op scale") {
-                decodedParams["w"].shouldEqual("120")
-                decodedParams["h"].shouldEqual("100")
+                decodedParams["w"] shouldEqual "120"
+                decodedParams["h"] shouldEqual "100"
             }
 
             it("sets horizontal insets") {
-                optimizedConfiguration.insets.left.shouldEqual(11) // TODO: maybe should be 12? rounding accumulation
-                optimizedConfiguration.insets.right.shouldEqual(11)
-                optimizedConfiguration.insets.top.shouldEqual(0)
-                optimizedConfiguration.insets.bottom.shouldEqual(0)
+                optimizedConfiguration.insets.left shouldEqual 11 // TODO: maybe should be 12? rounding accumulation
+                optimizedConfiguration.insets.right shouldEqual 11
+                optimizedConfiguration.insets.top shouldEqual 0
+                optimizedConfiguration.insets.bottom shouldEqual 0
             }
         }
 
@@ -235,19 +235,19 @@ object ImageOptimizationServiceSpec : Spek({
             val decodedParams = decodeUriParams(uri)
 
             it("asks imgix to crop the sides") {
-                decodedParams["rect"].shouldEqual("10,0,100,100")
+                decodedParams["rect"] shouldEqual "10,0,100,100"
             }
 
             it("asks imgix for a no-op scale") {
-                decodedParams["w"].shouldEqual("100")
-                decodedParams["h"].shouldEqual("100")
+                decodedParams["w"] shouldEqual "100"
+                decodedParams["h"] shouldEqual "100"
             }
 
             it("sets zero insets for the width dimension because the crop was done for us by imgix") {
-                optimizedConfiguration.insets.left.shouldEqual(0)
-                optimizedConfiguration.insets.right.shouldEqual(0)
-                optimizedConfiguration.insets.top.shouldEqual(0)
-                optimizedConfiguration.insets.bottom.shouldEqual(0)
+                optimizedConfiguration.insets.left shouldEqual 0
+                optimizedConfiguration.insets.right shouldEqual 0
+                optimizedConfiguration.insets.top shouldEqual 0
+                optimizedConfiguration.insets.bottom shouldEqual 0
             }
         }
 
@@ -262,19 +262,19 @@ object ImageOptimizationServiceSpec : Spek({
 
             it("asks imgix for a crop") {
                 // we wouldn't want imgix to scale up for us, that would be a waste.
-                decodedParams["rect"].shouldEqual("10,0,100,100")
+                decodedParams["rect"] shouldEqual "10,0,100,100"
             }
 
             it("asks imgix for a no-op scale") {
-                decodedParams["w"].shouldEqual("100")
-                decodedParams["h"].shouldEqual("100")
+                decodedParams["w"] shouldEqual "100"
+                decodedParams["h"] shouldEqual "100"
             }
 
             it("sets zero insets for the width dimension because the crop was done for us by imgix") {
-                optimizedConfiguration.insets.left.shouldEqual(0)
-                optimizedConfiguration.insets.right.shouldEqual(0)
-                optimizedConfiguration.insets.top.shouldEqual(0)
-                optimizedConfiguration.insets.bottom.shouldEqual(0)
+                optimizedConfiguration.insets.left shouldEqual 0
+                optimizedConfiguration.insets.right shouldEqual 0
+                optimizedConfiguration.insets.top shouldEqual 0
+                optimizedConfiguration.insets.bottom shouldEqual 0
             }
         }
 
@@ -288,19 +288,19 @@ object ImageOptimizationServiceSpec : Spek({
             val decodedParams = decodeUriParams(uri)
 
             it("asks imgix for a no-op crop") {
-                decodedParams["rect"].shouldEqual("0,0,120,100")
+                decodedParams["rect"] shouldEqual "0,0,120,100"
             }
 
             it("asks imgix to scale down by a factor of three ") {
-                decodedParams["w"].shouldEqual("40")
-                decodedParams["h"].shouldEqual("33")
+                decodedParams["w"] shouldEqual "40"
+                decodedParams["h"] shouldEqual "33"
             }
 
             it("sets exactly fitting insets") {
-                optimizedConfiguration.insets.left.shouldEqual(0)
-                optimizedConfiguration.insets.top.shouldEqual(0)
-                optimizedConfiguration.insets.right.shouldEqual(0)
-                optimizedConfiguration.insets.bottom.shouldEqual(0)
+                optimizedConfiguration.insets.left shouldEqual 0
+                optimizedConfiguration.insets.top shouldEqual 0
+                optimizedConfiguration.insets.right shouldEqual 0
+                optimizedConfiguration.insets.bottom shouldEqual 0
             }
         }
 
@@ -314,19 +314,19 @@ object ImageOptimizationServiceSpec : Spek({
             val decodedParams = decodeUriParams(uri)
 
             it("asks imgix for a crop") {
-                decodedParams["rect"].shouldEqual("10,0,100,100")
+                decodedParams["rect"] shouldEqual "10,0,100,100"
             }
 
             it("asks imgix to scale down") {
-                decodedParams["w"].shouldEqual("33")
-                decodedParams["h"].shouldEqual("33")
+                decodedParams["w"] shouldEqual "33"
+                decodedParams["h"] shouldEqual "33"
             }
 
             it("sets exactly fitting insets") {
-                optimizedConfiguration.insets.left.shouldEqual(0)
-                optimizedConfiguration.insets.top.shouldEqual(0)
-                optimizedConfiguration.insets.right.shouldEqual(0)
-                optimizedConfiguration.insets.bottom.shouldEqual(0)
+                optimizedConfiguration.insets.left shouldEqual 0
+                optimizedConfiguration.insets.top shouldEqual 0
+                optimizedConfiguration.insets.right shouldEqual 0
+                optimizedConfiguration.insets.bottom shouldEqual 0
             }
         }
 
@@ -340,19 +340,19 @@ object ImageOptimizationServiceSpec : Spek({
             val decodedParams = decodeUriParams(uri)
 
             it("asks imgix for a no-op crop") {
-                decodedParams["rect"].shouldEqual("0,0,120,100")
+                decodedParams["rect"] shouldEqual "0,0,120,100"
             }
 
             it("asks imgix to scale down") {
-                decodedParams["w"].shouldEqual("40")
-                decodedParams["h"].shouldEqual("33")
+                decodedParams["w"] shouldEqual "40"
+                decodedParams["h"] shouldEqual "33"
             }
 
             it("sets horizontal insets") {
-                optimizedConfiguration.insets.left.shouldEqual(3)
-                optimizedConfiguration.insets.right.shouldEqual(3)
-                optimizedConfiguration.insets.top.shouldEqual(0)
-                optimizedConfiguration.insets.bottom.shouldEqual(0)
+                optimizedConfiguration.insets.left shouldEqual 3
+                optimizedConfiguration.insets.right shouldEqual 3
+                optimizedConfiguration.insets.top shouldEqual 0
+                optimizedConfiguration.insets.bottom shouldEqual 0
             }
         }
     }

--- a/sdk/src/test/kotlin/io/rover/sdk/assets/ImageOptimizationServiceSpec.kt
+++ b/sdk/src/test/kotlin/io/rover/sdk/assets/ImageOptimizationServiceSpec.kt
@@ -1,12 +1,12 @@
 package io.rover.sdk.assets
 
+import io.rover.helpers.shouldEqual
 import io.rover.sdk.data.domain.Background
 import io.rover.sdk.data.domain.BackgroundContentMode
 import io.rover.sdk.data.domain.BackgroundScale
 import io.rover.sdk.data.domain.Color
 import io.rover.sdk.data.domain.Image
 import io.rover.sdk.ui.PixelSize
-import org.amshove.kluent.shouldEqual
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.net.URI

--- a/sdk/src/test/kotlin/io/rover/sdk/ui/ModelFactories.kt
+++ b/sdk/src/test/kotlin/io/rover/sdk/ui/ModelFactories.kt
@@ -119,7 +119,7 @@ internal fun DisplayItem.shouldMatch(
     type: Class<out LayoutableViewModel>,
     clip: RectF? = null
 ) {
-    this.position.shouldEqual(position)
-    this.viewModel.shouldBeInstanceOf(type)
-    this.clip.shouldEqual(clip)
+    this.position shouldEqual position
+    this.viewModel shouldBeInstanceOf type
+    this.clip shouldEqual clip
 }

--- a/sdk/src/test/kotlin/io/rover/sdk/ui/ModelFactories.kt
+++ b/sdk/src/test/kotlin/io/rover/sdk/ui/ModelFactories.kt
@@ -1,5 +1,7 @@
 package io.rover.sdk.ui
 
+import io.rover.helpers.shouldBeInstanceOf
+import io.rover.helpers.shouldEqual
 import io.rover.sdk.data.domain.Background
 import io.rover.sdk.data.domain.BackgroundContentMode
 import io.rover.sdk.data.domain.BackgroundScale
@@ -20,8 +22,6 @@ import io.rover.sdk.data.domain.TitleBarButtons
 import io.rover.sdk.data.domain.VerticalAlignment
 import io.rover.sdk.ui.blocks.concerns.layout.LayoutableViewModel
 import io.rover.sdk.ui.layout.DisplayItem
-import org.amshove.kluent.shouldBeInstanceOf
-import org.amshove.kluent.shouldEqual
 
 internal class ModelFactories {
     companion object {

--- a/sdk/src/test/kotlin/io/rover/sdk/ui/RenderingIntegrationSpec.kt
+++ b/sdk/src/test/kotlin/io/rover/sdk/ui/RenderingIntegrationSpec.kt
@@ -1,5 +1,8 @@
 package io.rover.sdk.ui
 
+import com.nhaarman.mockitokotlin2.mock
+import io.rover.helpers.shouldBeLessThan
+import io.rover.helpers.shouldEqual
 import io.rover.sdk.ViewModels
 import io.rover.sdk.logging.GlobalStaticLogHolder
 import io.rover.sdk.logging.JvmLogger
@@ -7,9 +10,6 @@ import io.rover.sdk.logging.log
 import io.rover.sdk.data.domain.Experience
 import io.rover.sdk.data.operations.data.decodeJson
 import io.rover.sdk.ui.layout.Layout
-import org.amshove.kluent.mock
-import org.amshove.kluent.shouldBeLessThan
-import org.amshove.kluent.shouldEqual
 import org.json.JSONObject
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe

--- a/sdk/src/test/kotlin/io/rover/sdk/ui/RenderingIntegrationSpec.kt
+++ b/sdk/src/test/kotlin/io/rover/sdk/ui/RenderingIntegrationSpec.kt
@@ -20,7 +20,7 @@ class RenderingIntegrationSpec : Spek({
         context("test suite run") {
             val parsedJson = JSONObject("""{"a": 42}""")
             it("can parse a value out of JSON") {
-                parsedJson.getInt("a").shouldEqual(42)
+                parsedJson.getInt("a") shouldEqual 42
             }
         }
     }
@@ -62,7 +62,7 @@ class RenderingIntegrationSpec : Spek({
             log.v("Took $renderTimeMs ms to render all ${experience.screens.count()} screens.")
 
             it("should have taken") {
-                renderTimeMs.shouldBeLessThan(200)
+                renderTimeMs shouldBeLessThan 200
             }
         }
     }

--- a/sdk/src/test/kotlin/io/rover/sdk/ui/RowViewModelSpec.kt
+++ b/sdk/src/test/kotlin/io/rover/sdk/ui/RowViewModelSpec.kt
@@ -61,7 +61,7 @@ object RowViewModelSpec : Spek({
                 val frame = rowViewModel.frame(RectF(0f, 0f, 60f, 0f))
 
                 it("expands its height to contain the blocks") {
-                    frame.bottom.shouldEqual(90f)
+                    frame.bottom shouldEqual 90f
                 }
             }
 
@@ -69,7 +69,7 @@ object RowViewModelSpec : Spek({
                 val frame = rowViewModel.frame(RectF(0f, 0f, 0f, 0f))
 
                 it("expands its height to contain the blocks") {
-                    frame.bottom.shouldEqual(90f)
+                    frame.bottom shouldEqual 90f
                 }
             }
 
@@ -141,7 +141,7 @@ object RowViewModelSpec : Spek({
                 // for either setting their own height or measuring their stacked auto-height.
                 val frame = rowViewModel.frame(RectF(0f, 0f, 60f, 0f))
                 it("sets its height as the given value") {
-                    frame.bottom.shouldEqual(20f)
+                    frame.bottom shouldEqual 20f
                 }
             }
 
@@ -187,7 +187,7 @@ object RowViewModelSpec : Spek({
                 // for either setting their own height or measuring their stacked auto-height.
                 val frame = rowViewModel.frame(RectF(0f, 0f, 60f, 0f))
                 it("sets its height as the given value") {
-                    frame.bottom.shouldEqual(20f)
+                    frame.bottom shouldEqual 20f
                 }
             }
 

--- a/sdk/src/test/kotlin/io/rover/sdk/ui/RowViewModelSpec.kt
+++ b/sdk/src/test/kotlin/io/rover/sdk/ui/RowViewModelSpec.kt
@@ -1,5 +1,7 @@
 package io.rover.sdk.ui
 
+import com.nhaarman.mockitokotlin2.mock
+import io.rover.helpers.shouldEqual
 import io.rover.sdk.ViewModels
 import io.rover.sdk.data.domain.Height
 import io.rover.sdk.data.domain.HorizontalAlignment
@@ -7,8 +9,6 @@ import io.rover.sdk.data.domain.Position
 import io.rover.sdk.data.domain.VerticalAlignment
 import io.rover.sdk.ui.blocks.rectangle.RectangleBlockViewModelInterface
 import io.rover.sdk.ui.layout.row.RowViewModel
-import org.amshove.kluent.mock
-import org.amshove.kluent.shouldEqual
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 

--- a/sdk/src/test/kotlin/io/rover/sdk/ui/ScreenViewModelSpec.kt
+++ b/sdk/src/test/kotlin/io/rover/sdk/ui/ScreenViewModelSpec.kt
@@ -1,5 +1,6 @@
 package io.rover.sdk.ui
 
+import com.nhaarman.mockitokotlin2.mock
 import io.rover.sdk.ViewModels
 import io.rover.sdk.data.domain.Height
 import io.rover.sdk.data.domain.HorizontalAlignment
@@ -7,7 +8,6 @@ import io.rover.sdk.data.domain.Position
 import io.rover.sdk.data.domain.VerticalAlignment
 import io.rover.sdk.ui.blocks.rectangle.RectangleBlockViewModel
 import io.rover.sdk.ui.layout.row.RowViewModel
-import org.amshove.kluent.mock
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 

--- a/sdk/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/sdk/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Description
- Removed junit4
- Removed hamkrest
- Removed kluent
- Added mockitokotlin2 to enable mocking of final classes
- Added assertion helpers to provide infix function support for junit assertions
- Changed infix function invocation style as call sites
- Closed classes that were previously open for testability purposes

closes issue #368 