### PR TITLE
Add Transforming Experiences

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
@@ -102,6 +102,27 @@ open class Rover(
      */
     private val chromeTabBackgroundColor: Int
 ) {
+    var experienceTransformer: ((Experience) -> Experience)? = null
+        private set
+
+    /**
+     * Sets an experience transformer on the [Rover] object enabling retrieved experiences to be altered
+     * in the desired way. The transformer is called on the UI thread so the transformer shouldn't block
+     * the thread.
+     */
+    fun setExperienceTransformer(experienceTransformer: (Experience) -> Experience) {
+        this.experienceTransformer = experienceTransformer
+    }
+
+    fun removeExperienceTransformer() {
+        experienceTransformer = null
+    }
+
+    /**
+     * Public in order to be accessible for capturing events for analytics and automation.
+     */
+    val eventEmitter: EventEmitter = EventEmitter()
+
     private val endpoint: String = "https://api.rover.io/graphql"
 
     private val mainScheduler: Scheduler = Scheduler.forAndroidMainThread()
@@ -125,11 +146,6 @@ open class Rover(
     private val localStorage: LocalStorage = LocalStorage(application)
 
     private val sessionStore: SessionStore = SessionStore(localStorage)
-
-    /**
-     * Public in order to be accessible for capturing events for analytics and automation.
-     */
-    val eventEmitter: EventEmitter = EventEmitter()
 
     private val analyticsService: AnalyticsService = AnalyticsService(
         application,
@@ -165,9 +181,6 @@ open class Rover(
         )
     }
 
-    var experienceTransformer: ((Experience) -> Experience)? = null
-    private set
-
     companion object {
         /**
          * Be sure to always call this before [Rover.initialize] in your Application's onCreate()!
@@ -187,21 +200,6 @@ open class Rover(
         @JvmOverloads
         fun initialize(application: Application, accountToken: String, @ColorInt chromeTabColor: Int = Color.BLACK) {
             shared = Rover(application = application, accountToken = accountToken, chromeTabBackgroundColor = chromeTabColor)
-        }
-
-        /**
-         * Sets an experience transformer on the [Rover] object enabling retrieved experiences to be altered
-         * in the desired way. The transformer is called on the UI thread so the transformer shouldn't block
-         * the thread.
-         */
-        @JvmStatic
-        fun setExperienceTransformer(experienceTransformer: (Experience) -> Experience) {
-            shared?.let { it.experienceTransformer = experienceTransformer } ?: log.w("Rover should be initialised before setting experience transformer.")
-        }
-
-        @JvmStatic
-        fun removeExperienceTransformer() {
-            shared?.experienceTransformer = null
         }
 
         /**

--- a/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
@@ -183,6 +183,8 @@ open class Rover(
             HttpClient.installSaneGlobalHttpCache(applicationContext)
         }
 
+        @JvmStatic
+        @JvmOverloads
         fun initialize(application: Application, accountToken: String, @ColorInt chromeTabColor: Int = Color.BLACK) {
             shared = Rover(application = application, accountToken = accountToken, chromeTabBackgroundColor = chromeTabColor)
         }
@@ -192,10 +194,12 @@ open class Rover(
          * in the desired way. The transformer is called on the UI thread so the transformer shouldn't block
          * the thread.
          */
+        @JvmStatic
         fun setExperienceTransformer(experienceTransformer: (Experience) -> Experience) {
             shared?.let { it.experienceTransformer = experienceTransformer } ?: log.w("Rover should be initialised before setting experience transformer.")
         }
 
+        @JvmStatic
         fun removeExperienceTransformer() {
             shared?.experienceTransformer = null
         }

--- a/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
@@ -165,6 +165,9 @@ open class Rover(
         )
     }
 
+    var experienceTransformer: ((Experience) -> Experience)? = null
+    private set
+
     companion object {
         /**
          * Be sure to always call this before [Rover.initialize] in your Application's onCreate()!
@@ -182,6 +185,19 @@ open class Rover(
 
         fun initialize(application: Application, accountToken: String, @ColorInt chromeTabColor: Int = Color.BLACK) {
             shared = Rover(application = application, accountToken = accountToken, chromeTabBackgroundColor = chromeTabColor)
+        }
+
+        /**
+         * Sets an experience transformer on the [Rover] object enabling retrieved experiences to be altered
+         * in the desired way. The transformer is called on the UI thread so the transformer shouldn't block
+         * the thread.
+         */
+        fun setExperienceTransformer(experienceTransformer: (Experience) -> Experience) {
+            shared?.let { it.experienceTransformer = experienceTransformer } ?: log.w("Rover should be initialised before setting experience transformer.")
+        }
+
+        fun removeExperienceTransformer() {
+            shared?.experienceTransformer = null
         }
 
         /**
@@ -210,7 +226,8 @@ internal class ViewModels(
     fun experienceViewModel(
         experienceRequest: RoverViewModel.ExperienceRequest,
         campaignId: String?,
-        activityLifecycle: Lifecycle
+        activityLifecycle: Lifecycle,
+        experienceTransformer: ((Experience) -> Experience)? = Rover.shared?.experienceTransformer
     ): RoverViewModel {
         return RoverViewModel(
             experienceRequest = experienceRequest,
@@ -218,7 +235,8 @@ internal class ViewModels(
             mainThreadScheduler = mainScheduler,
             resolveNavigationViewModel = { experience, icicle ->
                 experienceNavigationViewModel(experience, campaignId, activityLifecycle, icicle)
-            }
+            },
+            experienceTransformer = experienceTransformer
         )
     }
 

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/RoverViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/RoverViewModel.kt
@@ -30,7 +30,8 @@ internal class RoverViewModel(
     private val graphQlApiService: GraphQlApiService,
     private val mainThreadScheduler: Scheduler,
     private val resolveNavigationViewModel: (experience: Experience, icicle: Parcelable?) -> NavigationViewModelInterface,
-    private val icicle: Parcelable? = null
+    private val icicle: Parcelable? = null,
+    private val experienceTransformer: ((Experience) -> Experience)? = null
 ) : RoverViewModelInterface {
 
     override val state: Parcelable
@@ -154,8 +155,10 @@ internal class RoverViewModel(
         // yields an experience navigation view model. used by both our view and some of the
         // internal subscribers below.
         navigationViewModel = experiences.map { experience ->
+            val transformedExperience = experienceTransformer?.invoke(experience) ?: experience
+
             resolveNavigationViewModel(
-                experience,
+                transformedExperience,
                 // allow it to restore from state if there is any.
                 (state as State).navigationState
             ).apply {


### PR DESCRIPTION
## Description
- Add setting and removing an experience transformer via a higher order 
- Add annotation to `Rover` companion object functions for Java compatibility

### Calling from Kotlin
```kotlin
override fun onCreate() {
        super.onCreate()
        // initialize Rover SDK:
        Rover.installSaneGlobalHttpCache(this)
        Rover.initialize(this, getString(R.string.rover_api_token))
        Rover.setExperienceTransformer {
            it.copy(screens = listOf(it.screens.first().copy(titleBar = it.screens.first().titleBar.copy(text = "CHANGED IT"))))
        }
    }
```

### Calling from Java
```java
public void onCreate() {
        super.onCreate();
        // initialize Rover SDK:
        Rover.installSaneGlobalHttpCache(this);
        Rover.initialize(this, getString(R.string.rover_api_token));
        Rover.setExperienceTransformer(new Function1<Experience, Experience>() {
            @Override
            public Experience invoke(Experience experience) {
                return new Experience();
            }
        });
    }
```
closes #371 