### PR TITLE
Allow for custom behaviour on Button Blocks

### DIFF
--- a/example-app/src/main/res/values/constants.xml
+++ b/example-app/src/main/res/values/constants.xml
@@ -3,5 +3,4 @@
     <string name="rover_api_token">blank</string>
     <string name="uri_scheme">example</string>
     <string name="associated_domain">blank</string>
-    <string name="experience_id">blank</string>
 </resources>

--- a/sdk/src/main/kotlin/io/rover/sdk/data/domain/Experience.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/domain/Experience.kt
@@ -107,7 +107,7 @@ interface Block {
 
         data class PresentWebsite(val url: URI) : TapBehavior()
 
-        class None : TapBehavior()
+        object None : TapBehavior()
 
         companion object
     }

--- a/sdk/src/main/kotlin/io/rover/sdk/data/operations/data/Experience.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/operations/data/Experience.kt
@@ -597,10 +597,8 @@ internal fun ImageBlock.Companion.decodeJson(json: JSONObject): ImageBlock {
 }
 
 internal fun Block.TapBehavior.Companion.decodeJson(json: JSONObject): Block.TapBehavior {
-    val typeName = json.safeGetString("__typename")
-
-    return when (typeName) {
-        "NoneBlockTapBehavior" -> Block.TapBehavior.None()
+    return when (val typeName = json.safeGetString("__typename")) {
+        "NoneBlockTapBehavior" -> Block.TapBehavior.None
         "OpenURLBlockTapBehavior" -> Block.TapBehavior.OpenUri(
             uri = json.safeGetUri("url")
         )

--- a/sdk/src/main/kotlin/io/rover/sdk/services/EventEmitter.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/EventEmitter.kt
@@ -20,7 +20,7 @@ class EventEmitter {
 
     internal fun trackEvent(roverEvent: RoverEvent) {
         eventSubject.onNext(roverEvent)
-        log.d("Event emitted: ${roverEvent.toString()}")
+        log.d("Event emitted: ${roverEvent}")
         when (roverEvent) {
             is RoverEvent.BlockTapped -> listeners.forEach { it.onBlockTapped(roverEvent) }
             is RoverEvent.ExperienceDismissed -> listeners.forEach {

--- a/sdk/src/main/kotlin/io/rover/sdk/services/EventEmitter.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/EventEmitter.kt
@@ -1,6 +1,7 @@
 package io.rover.sdk.services
 
 import io.rover.sdk.data.events.RoverEvent
+import io.rover.sdk.logging.log
 import io.rover.sdk.streams.PublishSubject
 import io.rover.sdk.streams.share
 import org.reactivestreams.Publisher
@@ -19,6 +20,7 @@ class EventEmitter {
 
     internal fun trackEvent(roverEvent: RoverEvent) {
         eventSubject.onNext(roverEvent)
+        log.d("Event emitted: ${roverEvent.toString()}")
         when (roverEvent) {
             is RoverEvent.BlockTapped -> listeners.forEach { it.onBlockTapped(roverEvent) }
             is RoverEvent.ExperienceDismissed -> listeners.forEach {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/BlockViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/BlockViewModel.kt
@@ -4,6 +4,7 @@ import io.rover.sdk.ui.layout.ViewType
 import io.rover.sdk.ui.layout.screen.ScreenViewModel
 import io.rover.sdk.ui.navigation.NavigateToFromBlock
 import io.rover.sdk.data.domain.Block
+import io.rover.sdk.data.domain.ButtonBlock
 import io.rover.sdk.data.domain.Height
 import io.rover.sdk.data.domain.HorizontalAlignment
 import io.rover.sdk.data.domain.VerticalAlignment
@@ -145,7 +146,7 @@ internal class BlockViewModel(
     override val events = eventSource.share()
 
     override val isClickable: Boolean
-    get() = true
+    get() = this.block is ButtonBlock || this.block.tapBehavior != Block.TapBehavior.None
 
     override fun click() {
         // I don't have an epic (any other asynchronous behaviour to compose) here, just a single

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/BlockViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/BlockViewModel.kt
@@ -146,7 +146,7 @@ internal class BlockViewModel(
     override val events = eventSource.share()
 
     override val isClickable: Boolean
-    get() = this.block is ButtonBlock || this.block.tapBehavior != Block.TapBehavior.None
+    get() = block is ButtonBlock || block.tapBehavior != Block.TapBehavior.None
 
     override fun click() {
         // I don't have an epic (any other asynchronous behaviour to compose) here, just a single

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/BlockViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/layout/BlockViewModel.kt
@@ -145,7 +145,7 @@ internal class BlockViewModel(
     override val events = eventSource.share()
 
     override val isClickable: Boolean
-    get() = block.tapBehavior !is Block.TapBehavior.None
+    get() = true
 
     override fun click() {
         // I don't have an epic (any other asynchronous behaviour to compose) here, just a single
@@ -156,7 +156,7 @@ internal class BlockViewModel(
             is Block.TapBehavior.GoToScreen -> { NavigateToFromBlock.GoToScreenAction(tapBehavior.screenId, block) }
             is Block.TapBehavior.OpenUri -> { NavigateToFromBlock.External(tapBehavior.uri, block) }
             is Block.TapBehavior.PresentWebsite -> { NavigateToFromBlock.PresentWebsiteAction(tapBehavior.url, block) }
-            is Block.TapBehavior.None -> return
+            is Block.TapBehavior.None -> { NavigateToFromBlock.None(block) }
         }
 
         navigateTo.whenNotNull {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/navigation/NavigateToFromBlock.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/navigation/NavigateToFromBlock.kt
@@ -26,4 +26,8 @@ internal sealed class NavigateToFromBlock(
         val url: URI,
         block: Block
     ) : NavigateToFromBlock(block)
+
+    class None(
+        block: Block
+    ) : NavigateToFromBlock(block)
 }

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/navigation/NavigationViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/navigation/NavigationViewModel.kt
@@ -124,15 +124,16 @@ internal class NavigationViewModel(
 
         // observe actions and emit analytics events
         actions.subscribe { action ->
-
             when (action) {
                 is Action.Navigate -> {
                     eventEmitter.trackEvent(
-                        RoverEvent.BlockTapped(experience,
+                        RoverEvent.BlockTapped(
+                            experience,
                             action.sourceScreenViewModel.screen,
                             action.navigateTo.block,
                             action.row,
-                        campaignId)
+                            campaignId
+                        )
                     )
                 }
             }

--- a/sdk/src/test/kotlin/io/rover/sdk/ui/ModelFactories.kt
+++ b/sdk/src/test/kotlin/io/rover/sdk/ui/ModelFactories.kt
@@ -78,7 +78,7 @@ internal class ModelFactories {
 
         fun emptyRectangleBlock(): RectangleBlock {
             return RectangleBlock(
-                tapBehavior = Block.TapBehavior.None(),
+                tapBehavior = Block.TapBehavior.None,
                 position = Position(
                     horizontalAlignment = HorizontalAlignment.Fill(
                         0.0, 0.0


### PR DESCRIPTION
Requirement:

* Allow for custom integration Block Tapped handlers by customers where they are not able to use a deep link as the target.

Currently, the SDK only emits Block Tapped events if the block has an Action other than None assigned.  Indeed, we only mark those blocks that have an Action set as Clickable/Selectable to the Android & iOS UI frameworks.  Setting all the blocks as clickable (so as to allow us to pick up the click events and then dispatch our Block Tapped events), however, is no solution because it defeats the purpose of Views being set clickable, thus breaking a11y (screenreader and the like) and potentially other functionality.

In the future, we may consider adding a "Custom" action type that must be selected instead of None in order to receive the events.  In the meantime, we will instead assume that Buttons are always meant to be clickable, and only mark other Block types as clickable if they have a non-None action type set.