### PR TITLE
Bug/403 - Image poll images drawn over border

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
@@ -245,9 +245,8 @@ internal class ImagePollOptionView(context: Context?) : LinearLayout(context) {
         )
     }
 
-    override fun onDraw(canvas: Canvas) {
-        super.onDraw(canvas)
-
+    override fun dispatchDraw(canvas: Canvas) {
+        super.dispatchDraw(canvas)
         roundRect?.let { roundRect ->
             roundRect.rectF.let {
                 if (roundRect.borderStrokeWidth != 0f) {


### PR DESCRIPTION
## Description
- Change drawing order of children and border so that border is drawn over the top of children

closes #403 