### PR TITLE
Fix animation when backgrounded bug

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
@@ -237,6 +237,8 @@ internal class ImagePollOptionView(context: Context?) : RelativeLayout(context) 
             }
         }
 
+        votingIndicatorBar.viewWidth = viewWidth.toFloat()
+
         if (shouldAnimate) {
             performResultsAnimation(votingShare, isSelectedOption)
         } else {


### PR DESCRIPTION
## Description 
Fix animation bug when returning to activity after backgrounded

When backgrounding the app after voting but before the results animation then returning to the app the bar isn't filled.    