### PR TITLE
Feature/428 - Add accessibility content descriptions

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
@@ -248,9 +248,9 @@ internal class ImagePollOptionView(context: Context?) : RelativeLayout(context) 
         isClickable = false
 
         contentDescription = if (isSelectedOption) {
-            "Your vote, ${option.text.rawValue}, has $votingShare percent of the votes"
+            "Your vote ${option.text.rawValue}, $votingShare percent"
         } else {
-            "${option.text.rawValue}, has $votingShare percent of the votes"
+            "${option.text.rawValue}, $votingShare percent"
         }
 
 

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
@@ -65,6 +65,10 @@ internal class ImagePollOptionView(context: Context?) : RelativeLayout(context) 
 
     private val shortAnimationDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
 
+    fun setContentDescription(optionIndex: Int) {
+        contentDescription = "${optionTextView.text}. Option $optionIndex"
+    }
+
     private val optionTextView = textView {
         setLineSpacing(0f, 1.0f)
         includeFontPadding = false
@@ -231,11 +235,19 @@ internal class ImagePollOptionView(context: Context?) : RelativeLayout(context) 
             )
 
             if (isSelectedOption) {
+
                 voteIndicatorView.measure(0, 0)
                 maxWidth =
                     viewWidth - voteIndicatorView.measuredWidth - (bottomSectionHorizontalMargin * 2) - (voteIndicatorView.layoutParams as MarginLayoutParams).marginStart
             }
         }
+
+        contentDescription = if (isSelectedOption) {
+            "Your vote, ${option.text.rawValue}, has $votingShare percent of the votes"
+        } else {
+            "${option.text.rawValue}, has $votingShare percent of the votes"
+        }
+
 
         votingIndicatorBar.viewWidth = viewWidth.toFloat()
 

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
@@ -109,9 +109,12 @@ internal class ImagePollOptionView(context: Context?) : RelativeLayout(context) 
         textAlignment = View.TEXT_ALIGNMENT_TEXT_END
     }
 
-    private val topSection = RelativeLayout(context)
+    private val topSection = RelativeLayout(context).apply {
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+    }
 
     private val bottomSection = relativeLayout {
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
         gravity = Gravity.CENTER
         setupLinearLayoutParams(
             width = ViewGroup.LayoutParams.MATCH_PARENT,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
@@ -242,6 +242,8 @@ internal class ImagePollOptionView(context: Context?) : RelativeLayout(context) 
             }
         }
 
+        isClickable = false
+
         contentDescription = if (isSelectedOption) {
             "Your vote, ${option.text.rawValue}, has $votingShare percent of the votes"
         } else {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ViewImagePoll.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ViewImagePoll.kt
@@ -166,7 +166,7 @@ internal class ViewImagePoll(override val view: LinearLayout) :
     private fun bindQuestion(imagePoll: ImagePoll, numberOfOptions: Int) {
         questionView.run {
             text = imagePoll.question.rawValue
-            contentDescription = "Poll with $numberOfOptions: ${imagePoll.question.rawValue}"
+            contentDescription = "Poll with $numberOfOptions options: ${imagePoll.question.rawValue}"
             gravity = imagePoll.question.alignment.convertToGravity()
             textSize = imagePoll.question.font.size.toFloat()
             setTextColor(imagePoll.question.color.asAndroidColor())

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ViewImagePoll.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ViewImagePoll.kt
@@ -37,6 +37,7 @@ internal class ViewImagePoll(override val view: LinearLayout) :
     private var optionViews = mapOf<String, ImagePollOptionView>()
 
     init {
+        view.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         view.addView(questionView)
     }
 
@@ -165,6 +166,7 @@ internal class ViewImagePoll(override val view: LinearLayout) :
     private fun bindQuestion(imagePoll: ImagePoll) {
         questionView.run {
             text = imagePoll.question.rawValue
+            contentDescription = "This is a poll. ${imagePoll.question.rawValue}. Swipe to hear options"
             gravity = imagePoll.question.alignment.convertToGravity()
             textSize = imagePoll.question.font.size.toFloat()
             setTextColor(imagePoll.question.color.asAndroidColor())
@@ -184,11 +186,15 @@ internal class ViewImagePoll(override val view: LinearLayout) :
 
     private fun createTwoOptionLayout() {
         view.addView(row1)
+
+        var indexForAccessibility = 1
         optionViews.forEach { (id, imagePollOptionView) ->
             row1.addView(imagePollOptionView)
+            imagePollOptionView.setContentDescription(indexForAccessibility)
             imagePollOptionView.setOnClickListener {
                 viewModelBinding?.viewModel?.castVote(id, optionViews.keys.toList())
             }
+            indexForAccessibility++
         }
     }
 
@@ -204,6 +210,7 @@ internal class ViewImagePoll(override val view: LinearLayout) :
             val isOnFirstRow = viewsAdded < 2
             if (isOnFirstRow) row1.addView(imagePollOptionView) else row2.addView(imagePollOptionView)
             viewsAdded ++
+            imagePollOptionView.setContentDescription(viewsAdded)
             imagePollOptionView.setOnClickListener { viewModelBinding?.viewModel?.castVote(id, optionViews.keys.toList()) }
         }
     }

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ViewImagePoll.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ViewImagePoll.kt
@@ -78,7 +78,7 @@ internal class ViewImagePoll(override val view: LinearLayout) :
                 view.removeView(row2)
             }
 
-            bindQuestion(viewModel.imagePoll)
+            bindQuestion(viewModel.imagePoll, viewModel.imagePoll.options.size)
             setupOptionViews(viewModel, imageLength)
 
             viewModel.multiImageUpdates.distinctUntilChanged().subscribe(
@@ -163,10 +163,10 @@ internal class ViewImagePoll(override val view: LinearLayout) :
         }
     }
 
-    private fun bindQuestion(imagePoll: ImagePoll) {
+    private fun bindQuestion(imagePoll: ImagePoll, numberOfOptions: Int) {
         questionView.run {
             text = imagePoll.question.rawValue
-            contentDescription = "This is a poll. ${imagePoll.question.rawValue}. Swipe to hear options"
+            contentDescription = "Poll with $numberOfOptions: ${imagePoll.question.rawValue}"
             gravity = imagePoll.question.alignment.convertToGravity()
             textSize = imagePoll.question.font.size.toFloat()
             setTextColor(imagePoll.question.color.asAndroidColor())

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
@@ -47,6 +47,7 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
         setLineSpacing(0f, 1.0f)
         includeFontPadding = false
         gravity = Gravity.CENTER_VERTICAL
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         val marginInPixels = 16.dpAsPx(resources.displayMetrics)
 
         setupRelativeLayoutParams(
@@ -62,6 +63,7 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
         maxLines = 1
         gravity = Gravity.CENTER_VERTICAL
         textAlignment = View.TEXT_ALIGNMENT_TEXT_START
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
 
         val marginInPixels = 8.dpAsPx(resources.displayMetrics)
 
@@ -82,6 +84,7 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
         id = ViewCompat.generateViewId()
         visibility = View.GONE
         maxLines = 1
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         setLineSpacing(0f, 1.0f)
         includeFontPadding = false
         gravity = Gravity.CENTER_VERTICAL

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
@@ -254,9 +254,9 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
         isClickable = false
 
         contentDescription = if (isSelectedOption) {
-            "Your vote, ${optionStyle.text.rawValue}, has $votingShare percent of the votes"
+            "Your vote ${optionStyle.text.rawValue}, $votingShare percent"
         } else {
-            "${optionStyle.text.rawValue}, has $votingShare percent of the votes"
+            "${optionStyle.text.rawValue}, $votingShare percent"
         }
 
         if (shouldAnimate) {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
@@ -248,6 +248,8 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
             maxWidth = viewWidth - widthOfOtherViews
         }
 
+        isClickable = false
+
         contentDescription = if (isSelectedOption) {
             "Your vote, ${optionStyle.text.rawValue}, has $votingShare percent of the votes"
         } else {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
@@ -139,6 +139,10 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
         addView(voteIndicatorView)
     }
 
+    fun setContentDescription(optionIndex: Int) {
+        contentDescription = "${optionTextView.text}. Option $optionIndex"
+    }
+
     fun initializeOptionViewLayout(optionStyle: TextPollOption) {
         val optionStyleHeight = optionStyle.height.dpAsPx(resources.displayMetrics)
         val optionMarginHeight = optionStyle.topMargin.dpAsPx(resources.displayMetrics)
@@ -242,6 +246,12 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
                 calculateWidthWithoutOptionText(voteIndicatorView, votePercentageText, isSelectedOption, maxVotingShare)
 
             maxWidth = viewWidth - widthOfOtherViews
+        }
+
+        contentDescription = if (isSelectedOption) {
+            "Your vote, ${optionStyle.text.rawValue}, has $votingShare percent of the votes"
+        } else {
+            "${optionStyle.text.rawValue}, has $votingShare percent of the votes"
         }
 
         if (shouldAnimate) {

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/ViewTextPoll.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/ViewTextPoll.kt
@@ -58,7 +58,7 @@ internal class ViewTextPoll(override val view: LinearLayout) : ViewTextPollInter
 
     override var viewModelBinding: MeasuredBindableView.Binding<TextPollViewModelInterface>? by ViewModelBinding(view, cancellationBlock = {timer = null}) { binding, subscriptionCallback ->
         binding?.viewModel?.let { viewModel ->
-            bindQuestion(viewModel.textPoll)
+            bindQuestion(viewModel.textPoll, viewModel.textPoll.options.size)
 
             if (optionViews.isNotEmpty()) {
                 optionViews.forEach { view.removeView(it.value) }
@@ -131,10 +131,10 @@ internal class ViewTextPoll(override val view: LinearLayout) : ViewTextPollInter
         informOptionBackgroundAboutSize(viewModel)
     }
 
-    private fun bindQuestion(textPoll: TextPoll) {
+    private fun bindQuestion(textPoll: TextPoll, numberOfOptions: Int) {
         questionView.run {
             text = textPoll.question.rawValue
-            contentDescription = "This is a poll. ${textPoll.question.rawValue}. Swipe to hear options"
+            contentDescription = "Poll with $numberOfOptions: ${textPoll.question.rawValue}"
             gravity = textPoll.question.alignment.convertToGravity()
             textSize = textPoll.question.font.size.toFloat()
             setTextColor(textPoll.question.color.asAndroidColor())

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/ViewTextPoll.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/ViewTextPoll.kt
@@ -46,6 +46,7 @@ internal class ViewTextPoll(override val view: LinearLayout) : ViewTextPollInter
         view.addView {
             questionView
         }
+        view.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
     }
 
     private var timer: Timer? = null
@@ -115,12 +116,16 @@ internal class ViewTextPoll(override val view: LinearLayout) : ViewTextPollInter
     }
 
     private fun setupOptionViews(viewModel: TextPollViewModelInterface) {
+
+        var indexForAccessibility = 1
         optionViews = createOptionViews(viewModel.textPoll)
         startListeningForOptionImageUpdates(viewModel.optionBackgroundViewModel, optionViews)
         optionViews.forEach { (optionId, optionView) ->
             view.addView(optionView)
+            optionView.setContentDescription(indexForAccessibility)
             optionView.setOnClickListener {
                 viewModelBinding?.viewModel?.castVote(optionId, viewModel.textPoll.options.map { it.id }) }
+            indexForAccessibility++
         }
 
         informOptionBackgroundAboutSize(viewModel)
@@ -129,6 +134,7 @@ internal class ViewTextPoll(override val view: LinearLayout) : ViewTextPollInter
     private fun bindQuestion(textPoll: TextPoll) {
         questionView.run {
             text = textPoll.question.rawValue
+            contentDescription = "This is a poll. ${textPoll.question.rawValue}. Swipe to hear options"
             gravity = textPoll.question.alignment.convertToGravity()
             textSize = textPoll.question.font.size.toFloat()
             setTextColor(textPoll.question.color.asAndroidColor())

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/ViewTextPoll.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/ViewTextPoll.kt
@@ -134,7 +134,7 @@ internal class ViewTextPoll(override val view: LinearLayout) : ViewTextPollInter
     private fun bindQuestion(textPoll: TextPoll, numberOfOptions: Int) {
         questionView.run {
             text = textPoll.question.rawValue
-            contentDescription = "Poll with $numberOfOptions: ${textPoll.question.rawValue}"
+            contentDescription = "Poll with $numberOfOptions options: ${textPoll.question.rawValue}"
             gravity = textPoll.question.alignment.convertToGravity()
             textSize = textPoll.question.font.size.toFloat()
             setTextColor(textPoll.question.color.asAndroidColor())

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/layout/screen/ScreenView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/layout/screen/ScreenView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Canvas
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
+import android.view.View
 import io.rover.sdk.Rover
 import io.rover.sdk.logging.log
 import io.rover.sdk.streams.PublishSubject
@@ -39,6 +40,8 @@ internal class ScreenView : RecyclerView, MeasuredBindableView<ScreenViewModelIn
     private val vtoMeasuredSizeSubject = PublishSubject<MeasuredSize>()
 
     init {
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+
         viewTreeObserver.addOnGlobalLayoutListener {
             vtoMeasuredSizeSubject.onNext(
                 MeasuredSize(


### PR DESCRIPTION
## Description 

The flow is the following:
1. Swipe onto poll -> _This is a poll. `poll question`. Swipe to hear options_ read out
2. Swipe onto option ->   _`option text`. Option `option index`, double tap to activate(added by system)_ 
3. Double tap poll option -> _Your vote, `option text`, has `votingShare` percent of the votes_
4. Swipe onto other option in result state -> _`option text`, has `votingShare` percent of the votes_

## Related issues
closes #428 