### PR TITLE
Feature/429 - Poll blocks inset by border width

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/platform/ViewGroupExtensions.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/ViewGroupExtensions.kt
@@ -158,5 +158,6 @@ internal fun Paint.create(paintColor: Int, paintStyle: Paint.Style, paintStrokeW
         color = paintColor
         style = paintStyle
         strokeWidth = paintStrokeWidth
+        isAntiAlias = true
     }
 }

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollOptionView.kt
@@ -164,6 +164,17 @@ internal class ImagePollOptionView(context: Context?) : RelativeLayout(context) 
     }
 
     fun bindOptionView(option: ImagePollBlockOption) {
+        val borderWidth = option.border.width.dpAsPx(resources.displayMetrics)
+
+        overallLinearLayout.setupRelativeLayoutParams(
+            width = ViewGroup.LayoutParams.MATCH_PARENT,
+            height = ViewGroup.LayoutParams.MATCH_PARENT,
+            leftMargin = borderWidth,
+            rightMargin = borderWidth,
+            topMargin = borderWidth,
+            bottomMargin = borderWidth
+        )
+
         bottomSection.layoutParams = (bottomSection.layoutParams as MarginLayoutParams).apply {
             setMargins(bottomSectionHorizontalMargin, 0, bottomSectionHorizontalMargin, 0)
         }

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ViewImagePoll.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ViewImagePoll.kt
@@ -67,8 +67,10 @@ internal class ViewImagePoll(override val view: LinearLayout) :
 
             val horizontalSpacing = viewModel.imagePoll.options[1].leftMargin
 
+            val borderWidth = viewModel.imagePoll.options.first().border.width.dpAsPx(view.resources.displayMetrics)
+
             val imageLength =
-                (width.dpAsPx(view.resources.displayMetrics) - horizontalSpacing.dpAsPx(view.resources.displayMetrics)) / 2
+                ((width.dpAsPx(view.resources.displayMetrics) - horizontalSpacing.dpAsPx(view.resources.displayMetrics)) / 2) - (borderWidth * 2)
 
             if (optionViews.isNotEmpty()) {
                 row1.removeAllViews()
@@ -209,14 +211,17 @@ internal class ViewImagePoll(override val view: LinearLayout) :
     }
 
     private fun createOptionViews(imagePoll: ImagePoll, imageLength: Int): Map<String, ImagePollOptionView> {
+        val borderWidth = imagePoll.options.first().border.width.dpAsPx(view.resources.displayMetrics)
+        val totalBorderWidth = borderWidth * 2
+
         return imagePoll.options.associate {
             it.id to view.imageOptionView {
-                initializeOptionViewLayout(it, imageLength + OPTION_TEXT_HEIGHT.toInt())
+                initializeOptionViewLayout(it, imageLength + OPTION_TEXT_HEIGHT.toInt() + totalBorderWidth)
                 bindOptionView(it)
                 bindOptionImageSize(imageLength)
                 setupLinearLayoutParams(
-                    width = imageLength,
-                    height = imageLength + OPTION_TEXT_HEIGHT.dpAsPx(view.resources.displayMetrics),
+                    width = imageLength + totalBorderWidth,
+                    height = imageLength + OPTION_TEXT_HEIGHT.dpAsPx(view.resources.displayMetrics) + totalBorderWidth,
                     leftMargin = it.leftMargin.dpAsPx(view.resources.displayMetrics),
                     topMargin = it.topMargin.dpAsPx(view.resources.displayMetrics)
                 )

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
@@ -237,7 +237,7 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
         val borderWidth = optionStyle.border.width.dpAsPx(resources.displayMetrics)
         val totalBorderWidth = borderWidth * 2
         val viewHeight = optionStyle.height.dpAsPx(resources.displayMetrics) + totalBorderWidth
-        val viewWidth = (optionWidth?.dpAsPx(resources.displayMetrics))?.minus(- totalBorderWidth)  ?: this@TextOptionView.width
+        val viewWidth = (optionWidth?.dpAsPx(resources.displayMetrics))?.minus(totalBorderWidth)  ?: nonBorderGroup.width
 
         textPollProgressBar.viewHeight = viewHeight.toFloat()
         textPollProgressBar.visibility = View.VISIBLE
@@ -273,7 +273,7 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
     private fun immediatelyGoToResultsState(votingShare: Int, resultFillAlpha: Int, viewWidth: Float, viewHeight: Float) {
         currentVote = votingShare
         textPollProgressBar.viewHeight = viewHeight
-        textPollProgressBar.barValue = viewWidth      / 100 * votingShare
+        textPollProgressBar.barValue = viewWidth / 100 * votingShare
         textPollProgressBar.visibility = View.VISIBLE
         votePercentageText.alpha = 1f
         optionPaints.resultPaint.alpha = resultFillAlpha
@@ -325,7 +325,7 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
             addUpdateListener {
                 val animatedValue = it.animatedValue as Float
                 votePercentageText.text = "${animatedValue.toInt()}%"
-                textPollProgressBar.barValue = width.toFloat() / 100 * animatedValue
+                textPollProgressBar.barValue = nonBorderGroup.width.toFloat() / 100 * animatedValue
             }
             interpolator = easeInEaseOutInterpolator
         }

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollOptionView.kt
@@ -3,7 +3,6 @@ package io.rover.sdk.ui.blocks.poll.text
 import android.animation.AnimatorSet
 import android.animation.TimeInterpolator
 import android.animation.ValueAnimator
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
@@ -21,9 +20,7 @@ import android.widget.RelativeLayout
 import io.rover.sdk.data.domain.FontWeight
 import io.rover.sdk.data.domain.TextPollOption
 import io.rover.sdk.data.mapToFont
-import io.rover.sdk.logging.log
 import io.rover.sdk.platform.create
-import io.rover.sdk.platform.relativeLayout
 import io.rover.sdk.platform.setBackgroundWithoutPaddingChange
 import io.rover.sdk.platform.setupLinearLayoutParams
 import io.rover.sdk.platform.setupRelativeLayoutParams
@@ -121,7 +118,7 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
         set(value) {
             field = value
             value?.let {
-                nonBorderGroup.setBackgroundWithoutPaddingChange(it)
+                mainLayout.setBackgroundWithoutPaddingChange(it)
             }
         }
 
@@ -132,15 +129,15 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
         private const val RESULT_FILL_ALPHA_DURATION = 50L
     }
 
-    private val nonBorderGroup = RelativeLayout(context)
+    private val mainLayout = RelativeLayout(context)
 
     init {
-        nonBorderGroup.addView(textPollProgressBar)
-        nonBorderGroup.addView(optionTextView)
-        nonBorderGroup.addView(votePercentageText)
-        nonBorderGroup.addView(voteIndicatorView)
+        mainLayout.addView(textPollProgressBar)
+        mainLayout.addView(optionTextView)
+        mainLayout.addView(votePercentageText)
+        mainLayout.addView(voteIndicatorView)
 
-        addView(nonBorderGroup)
+        addView(mainLayout)
         addView(borderView)
     }
 
@@ -160,7 +157,7 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
             topMargin = optionMarginHeight
         )
 
-        nonBorderGroup.setupRelativeLayoutParams {
+        mainLayout.setupRelativeLayoutParams {
             width = LayoutParams.MATCH_PARENT
             height = optionStyleHeight
             marginStart = borderWidth
@@ -237,7 +234,7 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
         val borderWidth = optionStyle.border.width.dpAsPx(resources.displayMetrics)
         val totalBorderWidth = borderWidth * 2
         val viewHeight = optionStyle.height.dpAsPx(resources.displayMetrics) + totalBorderWidth
-        val viewWidth = (optionWidth?.dpAsPx(resources.displayMetrics))?.minus(totalBorderWidth)  ?: nonBorderGroup.width
+        val viewWidth = (optionWidth?.dpAsPx(resources.displayMetrics))?.minus(totalBorderWidth)  ?: mainLayout.width
 
         textPollProgressBar.viewHeight = viewHeight.toFloat()
         textPollProgressBar.visibility = View.VISIBLE
@@ -325,7 +322,7 @@ internal class TextOptionView(context: Context?) : RelativeLayout(context) {
             addUpdateListener {
                 val animatedValue = it.animatedValue as Float
                 votePercentageText.text = "${animatedValue.toInt()}%"
-                textPollProgressBar.barValue = nonBorderGroup.width.toFloat() / 100 * animatedValue
+                textPollProgressBar.barValue = mainLayout.width.toFloat() / 100 * animatedValue
             }
             interpolator = easeInEaseOutInterpolator
         }

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollViewModel.kt
@@ -44,7 +44,11 @@ internal class TextPollViewModel(
         val optionsHeight = optionStyleHeight * textPoll.options.size
         val optionSpacing = verticalSpacing * (textPoll.options.size)
 
-        return optionsHeight + optionSpacing + questionHeight
+        val borderWidth = measurementService.snapToPixValue(textPoll.options.first().border.width)
+
+        val totalBorderWidth = borderWidth * textPoll.options.size * 2
+
+        return optionsHeight + optionSpacing + questionHeight + totalBorderWidth
     }
 
     override fun checkForUpdate(pollId: String, optionIds: List<String>) {


### PR DESCRIPTION
## Description
- Change text poll to react to an increase border width by increasing their intrinsic height
- Change image polls to react to an increase in border width be shrinking their views by an appropriate amount
- Added antialiasing to the border view paint to improve look of edges

## Related Issues 
closes #429 