### PR TITLE
Support fetching draft experiences.

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/ui/RoverViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/RoverViewModel.kt
@@ -75,7 +75,7 @@ internal class RoverViewModel(
                 is ExperienceRequest.ByUrl -> FetchExperienceRequest.ExperienceQueryIdentifier.ByUniversalLink(
                     experienceRequest.url
                 )
-                is ExperienceRequest.ById -> FetchExperienceRequest.ExperienceQueryIdentifier.ById(experienceRequest.experienceId)
+                is ExperienceRequest.ById -> FetchExperienceRequest.ExperienceQueryIdentifier.ById(experienceRequest.experienceId, experienceRequest.useDraft)
             }
         ).observeOn(mainThreadScheduler)
 
@@ -226,6 +226,6 @@ internal class RoverViewModel(
 
     sealed class ExperienceRequest {
         data class ByUrl(val url: String) : ExperienceRequest()
-        data class ById(val experienceId: String) : ExperienceRequest()
+        data class ById(val experienceId: String, val useDraft: Boolean = false) : ExperienceRequest()
     }
 }

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/containers/RoverActivity.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/containers/RoverActivity.kt
@@ -34,6 +34,8 @@ open class RoverActivity : AppCompatActivity() {
 
     private val experienceUrl: String? by lazy { this.intent.getStringExtra("EXPERIENCE_URL") }
 
+    private val useDraft: Boolean by lazy { this.intent.getBooleanExtra("USE_DRAFT", false) }
+
     private val campaignId: String?
         get() = this.intent.getStringExtra("CAMPAIGN_ID")
 
@@ -178,7 +180,7 @@ open class RoverActivity : AppCompatActivity() {
         when {
             experienceId != null -> roverViewModel = experienceViewModel(
                 rover,
-                RoverViewModel.ExperienceRequest.ById(experienceId!!),
+                RoverViewModel.ExperienceRequest.ById(experienceId!!, useDraft = useDraft),
                 campaignId,
                 // obtain any possibly saved state for the experience view model.  See
                 // onSaveInstanceState.
@@ -228,10 +230,11 @@ open class RoverActivity : AppCompatActivity() {
     companion object {
         @JvmStatic
         @JvmOverloads
-        fun makeIntent(packageContext: Context, experienceId: String, campaignId: String? = null, activityClass: Class<out Activity> = RoverActivity::class.java): Intent {
+        fun makeIntent(packageContext: Context, experienceId: String, campaignId: String? = null, useDraft: Boolean = false, activityClass: Class<out Activity> = RoverActivity::class.java): Intent {
             return Intent(packageContext, activityClass).apply {
                 putExtra("EXPERIENCE_ID", experienceId)
                 putExtra("CAMPAIGN_ID", campaignId)
+                putExtra("USE_DRAFT", useDraft)
             }
         }
 


### PR DESCRIPTION
Also now uses the two new GraphQL FetchExperience* endpoints rather than the old one that used arity to handle all cases.

Resolves #431.