### PR TITLE
Bug/437 - Cannot get from "Poll Answered" state to "Submitting Answer" state when Polls service is restored after user casting vote

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/VotingInteractor.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/VotingInteractor.kt
@@ -86,7 +86,7 @@ internal class VotingInteractor(
         getPollStateFromNetwork(pollId, optionIds).observeOn(mainScheduler).subscribe { optionResults ->
             val resultsSameKeysAsShown = optionResults.results.filterKeys { key -> key in optionIds }.size == optionIds.size
 
-            if (resultsSameKeysAsShown && optionResults.results.isNotEmpty()) currentState = VotingState.ResultsSeeded(optionResults)
+            if (resultsSameKeysAsShown && optionResults.results.isNotEmpty() && currentState is VotingState.InitialState) currentState = VotingState.ResultsSeeded(optionResults)
         }
     }
 


### PR DESCRIPTION
## Description
Stop initial results request returning voting interactor to `results seeded` state if user already in a more advanced state

## Related issue
closes #437 