### PR TITLE
Bug - Publisher in image poll view model fires more frequently than expected

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollViewModel.kt
@@ -106,7 +106,7 @@ internal class ImagePollViewModel(
                 val pixelSize = PixelSize(measuredSize.width.dpAsPx(measuredSize.density), measuredSize.height.dpAsPx(measuredSize.density))
                 val uriWithParameters = imageOptimizationService.optimizeImageForFill(it.value, pixelSize)
 
-                return@map assetService.imageByUrl(uriWithParameters.toURL()).map { bitmap ->
+                return@map assetService.imageByUrl(uriWithParameters.toURL()).distinctUntilChanged().map { bitmap ->
                     val timeElapsed = System.currentTimeMillis() - timestampMillis
                     val shouldFade = timeElapsed > IMAGE_FADE_IN_MINIMUM_TIME
                     it.key to ImagePollViewModelInterface.ImageUpdate(bitmap, shouldFade) }


### PR DESCRIPTION
## Description 
This seems to be due to image polls with multiple images with the same image urls causing multiple duplicate items to be emitted.

## Solution
Adding `distinctUntilChanged` so that duplicate items won't be emitted