### PR TITLE
Bug/452 - Fix poll id being added to Poll Answered event instead of option id

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/image/ImagePollViewModel.kt
@@ -110,7 +110,7 @@ internal class ImagePollViewModel(
     override fun castVote(selectedOption: String, optionIds: List<String>) {
         pollVotingInteractor.castVotes(selectedOption)
         imagePoll.options.find { it.id == selectedOption }?.let { option ->
-            eventEmitter.trackEvent(RoverEvent.PollAnswered(experience, screen, block, Option(id, option.text.rawValue, option.image?.url?.toString()), campaignId))
+            eventEmitter.trackEvent(RoverEvent.PollAnswered(experience, screen, block, Option(option.id, option.text.rawValue, option.image?.url?.toString()), campaignId))
         }
     }
 

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollViewModel.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/poll/text/TextPollViewModel.kt
@@ -52,7 +52,7 @@ internal class TextPollViewModel(
     override fun castVote(selectedOption: String, optionIds: List<String>) {
         pollVotingInteractor.castVotes(selectedOption)
         textPoll.options.find { it.id == selectedOption }?.let { option ->
-            eventEmitter.trackEvent(RoverEvent.PollAnswered(experience, screen, block, Option(id, option.text.rawValue), campaignId))
+            eventEmitter.trackEvent(RoverEvent.PollAnswered(experience, screen, block, Option(option.id, option.text.rawValue), campaignId))
         }
     }
 


### PR DESCRIPTION
## Description
Changed to pass in the `optionId` to the `PollAnswered` constructor instead of the `pollId`

## Related Issue
closes #452 