### PR TITLE
Bug/451 - Paragraph Spacing

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/platform/StringExtensions.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/platform/StringExtensions.kt
@@ -36,6 +36,6 @@ internal fun String.roverTextHtmlAsSpanned(): SpannableStringBuilder {
 
         spannedBuilder
     } else {
-        Html.fromHtml(this, Html.FROM_HTML_SEPARATOR_LINE_BREAK_PARAGRAPH) as SpannableStringBuilder
+        Html.fromHtml(this.replace("<p></p>", "<p>&nbsp;</p>"), Html.FROM_HTML_SEPARATOR_LINE_BREAK_PARAGRAPH) as SpannableStringBuilder
     }
 }


### PR DESCRIPTION
### Description 

Empty paragraph tags are ignored by the `Html.fromHtml()` function but the web preview and iOS don’t ignore these. I added a non-breaking space inside so that they would no longer be ignored.

### Screenshots

**Before:**
![Screenshot_20200401-102244](https://user-images.githubusercontent.com/20459878/78148686-286a4b00-7403-11ea-86c4-ff630aac33d3.png)

**After:**
![Screenshot_20200401-102420](https://user-images.githubusercontent.com/20459878/78148679-26a08780-7403-11ea-840b-4c86438afe5f.png)

### Related Issues
closes #451 