### PR TITLE
Bug/462 - textblock measurement issue

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/services/MeasurementService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/MeasurementService.kt
@@ -80,6 +80,7 @@ internal class MeasurementService(
                 fontAppearance.font.fontFamily, fontAppearance.font.fontStyle
             )
             textAlign = fontAppearance.align
+            isAntiAlias = true
         }
 
         val textLayoutAlign = when (fontAppearance.align) {


### PR DESCRIPTION
### Description 
Set antialias flag for `textPaint` in measurement service to true. The reason for this is that textpaint in textviews have this flag set to true by default. This seems to very occasionally cause a discrepancy between the measured height needed for text and the actual height of the text.

Having this flag true for the measurement should prevent this as it mirror the textpaint in textview.

Before:
![Screenshot_20200404-070022_Rover Example](https://user-images.githubusercontent.com/20459878/78413870-75a71200-75e7-11ea-8678-d711ff6d9fe1.jpg)

After:
![Screenshot_20200404-070243_Rover Example](https://user-images.githubusercontent.com/20459878/78413877-7770d580-75e7-11ea-8cad-d6805b5d25f6.jpg)
closes #462  