### PR TITLE
Add conversion tracking info to blocks & screens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.4.0.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 13 17:42:04 EDT 2019
+#Fri May 22 14:07:39 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/sdk/src/main/kotlin/io/rover/sdk/data/domain/Experience.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/domain/Experience.kt
@@ -92,7 +92,7 @@ interface Block {
     val keys: Map<String, String>
     val tags: List<String>
     val name: String
-    val trackingInfo: TrackingInfo?
+    val conversion: Conversion?
 
 
     sealed class TapBehavior {
@@ -144,7 +144,7 @@ data class ImagePollBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
-    override val trackingInfo: TrackingInfo?,
+    override val conversion: Conversion?,
     override val tags: List<String>,
     val imagePoll: ImagePoll
 ) : Block {
@@ -165,7 +165,7 @@ data class TextPollBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
-    override val trackingInfo: TrackingInfo?,
+    override val conversion: Conversion?,
     override val tags: List<String>,
     val textPoll: TextPoll
 ) : Block {
@@ -201,7 +201,7 @@ data class BarcodeBlock(
     @Deprecated("BarcodeBlock does not have a border.")
     override val border: Border,
     override val name: String,
-    override val trackingInfo: TrackingInfo?,
+    override val conversion: Conversion?,
     override val tags: List<String>,
     val barcode: Barcode
 ) : Block {
@@ -218,7 +218,7 @@ data class ButtonBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
-    override val trackingInfo: TrackingInfo?,
+    override val conversion: Conversion?,
     override val tags: List<String>,
     val text: Text
 ) : Block {
@@ -235,7 +235,7 @@ data class ImageBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
-    override val trackingInfo: TrackingInfo?,
+    override val conversion: Conversion?,
     override val tags: List<String>,
     val image: Image?
 ) : Block {
@@ -252,7 +252,7 @@ data class RectangleBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
-    override val trackingInfo: TrackingInfo?,
+    override val conversion: Conversion?,
     override val tags: List<String>
 ) : Block {
     companion object
@@ -268,7 +268,7 @@ data class TextBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
-    override val trackingInfo: TrackingInfo?,
+    override val conversion: Conversion?,
     override val tags: List<String>,
     val text: Text
 ) : Block {
@@ -285,7 +285,7 @@ data class WebViewBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
-    override val trackingInfo: TrackingInfo?,
+    override val conversion: Conversion?,
     override val tags: List<String>,
     val webView: WebView
 ) : Block {
@@ -469,7 +469,7 @@ data class Screen(
     val statusBar: StatusBar,
     val keys: Map<String, String>,
     val tags: List<String>,
-    val trackingInfo: TrackingInfo?,
+    val conversion: Conversion?,
     val name: String
 ) {
     companion object
@@ -562,8 +562,8 @@ enum class UnitOfMeasure(
     companion object
 }
 
-data class TrackingInfo(
-    val key: String,
+data class Conversion(
+    val tag: String,
     val expires: Duration
 ) {
     companion object

--- a/sdk/src/main/kotlin/io/rover/sdk/data/domain/Experience.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/domain/Experience.kt
@@ -92,6 +92,8 @@ interface Block {
     val keys: Map<String, String>
     val tags: List<String>
     val name: String
+    val trackingInfo: TrackingInfo?
+
 
     sealed class TapBehavior {
         /**
@@ -142,6 +144,7 @@ data class ImagePollBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
+    override val trackingInfo: TrackingInfo?,
     override val tags: List<String>,
     val imagePoll: ImagePoll
 ) : Block {
@@ -162,6 +165,7 @@ data class TextPollBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
+    override val trackingInfo: TrackingInfo?,
     override val tags: List<String>,
     val textPoll: TextPoll
 ) : Block {
@@ -197,6 +201,7 @@ data class BarcodeBlock(
     @Deprecated("BarcodeBlock does not have a border.")
     override val border: Border,
     override val name: String,
+    override val trackingInfo: TrackingInfo?,
     override val tags: List<String>,
     val barcode: Barcode
 ) : Block {
@@ -213,6 +218,7 @@ data class ButtonBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
+    override val trackingInfo: TrackingInfo?,
     override val tags: List<String>,
     val text: Text
 ) : Block {
@@ -229,6 +235,7 @@ data class ImageBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
+    override val trackingInfo: TrackingInfo?,
     override val tags: List<String>,
     val image: Image?
 ) : Block {
@@ -245,6 +252,7 @@ data class RectangleBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
+    override val trackingInfo: TrackingInfo?,
     override val tags: List<String>
 ) : Block {
     companion object
@@ -260,6 +268,7 @@ data class TextBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
+    override val trackingInfo: TrackingInfo?,
     override val tags: List<String>,
     val text: Text
 ) : Block {
@@ -276,6 +285,7 @@ data class WebViewBlock(
     override val background: Background,
     override val border: Border,
     override val name: String,
+    override val trackingInfo: TrackingInfo?,
     override val tags: List<String>,
     val webView: WebView
 ) : Block {
@@ -459,6 +469,7 @@ data class Screen(
     val statusBar: StatusBar,
     val keys: Map<String, String>,
     val tags: List<String>,
+    val trackingInfo: TrackingInfo?,
     val name: String
 ) {
     companion object
@@ -548,5 +559,23 @@ enum class UnitOfMeasure(
      */
     Percentage("PERCENTAGE");
 
+    companion object
+}
+
+data class TrackingInfo(
+    val key: String,
+    val expires: Duration
+) {
+    companion object
+}
+
+enum class DurationUnit {
+    SECONDS, MINUTES, HOURS, DAYS
+}
+
+data class Duration(
+    val value: String,
+    val unit: DurationUnit
+){
     companion object
 }

--- a/sdk/src/main/kotlin/io/rover/sdk/data/domain/Experience.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/domain/Experience.kt
@@ -574,8 +574,14 @@ enum class DurationUnit {
 }
 
 data class Duration(
-    val value: String,
+    val value: Int,
     val unit: DurationUnit
 ){
+    val seconds: Long = value.toLong().times( when(unit) {
+        DurationUnit.SECONDS -> 1
+        DurationUnit.MINUTES -> 60
+        DurationUnit.HOURS -> 60 * 60
+        DurationUnit.DAYS -> 60 * 60 * 24
+    })
     companion object
 }

--- a/sdk/src/main/kotlin/io/rover/sdk/data/operations/data/Experience.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/operations/data/Experience.kt
@@ -54,7 +54,6 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-private val DURATION_REGEX = Regex("^\\d+[smhd]$")
 
 internal fun Experience.Companion.decodeJson(json: JSONObject): Experience {
     return Experience(

--- a/sdk/src/main/kotlin/io/rover/sdk/data/operations/data/Experience.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/operations/data/Experience.kt
@@ -39,7 +39,7 @@ import io.rover.sdk.data.domain.TextPollBlock
 import io.rover.sdk.data.domain.TextPollOption
 import io.rover.sdk.data.domain.TitleBar
 import io.rover.sdk.data.domain.TitleBarButtons
-import io.rover.sdk.data.domain.TrackingInfo
+import io.rover.sdk.data.domain.Conversion
 import io.rover.sdk.data.domain.UnitOfMeasure
 import io.rover.sdk.data.domain.VerticalAlignment
 import io.rover.sdk.data.domain.WebView
@@ -389,7 +389,7 @@ internal fun BarcodeBlock.Companion.decodeJson(json: JSONObject): BarcodeBlock {
         keys = json.getJSONObject("keys").toStringHash(),
         barcode = Barcode.decodeJson(json.getJSONObject("barcode")),
         name = json.safeGetString("name"),
-        trackingInfo = TrackingInfo.optDecodeJson(json.optJSONObject("tracking")),
+        conversion = Conversion.optDecodeJson(json.optJSONObject("conversion")),
         tags = json.getJSONArray("tags").getStringIterable().toList()
     )
 }
@@ -442,14 +442,14 @@ internal fun Duration.encodeJson(): String  {
    return "${this.value}${this.unit.encodeJson()}"
 }
 
-internal fun TrackingInfo.encodeJson(): JSONObject {
+internal fun Conversion.encodeJson(): JSONObject {
     return JSONObject().apply {
-        putProp(this@encodeJson, TrackingInfo::key, "key")
-        putProp(this@encodeJson, TrackingInfo::expires, "expires") { it.encodeJson() }
+        putProp(this@encodeJson, Conversion::tag, "key")
+        putProp(this@encodeJson, Conversion::expires, "expires") { it.encodeJson() }
     }
 }
 
-internal fun TrackingInfo?.optEncodeJson(): JSONObject? {
+internal fun Conversion?.optEncodeJson(): JSONObject? {
     return this?.encodeJson()
 }
 
@@ -505,7 +505,7 @@ internal fun Block.encodeSharedJson(): JSONObject {
         putProp(this@encodeSharedJson, Block::border, "border") { it.encodeJson() }
         putProp(this@encodeSharedJson, Block::keys, "keys") { JSONObject(it) }
         putProp(this@encodeSharedJson, Block::name, "name") { it }
-        putProp(this@encodeSharedJson, Block::trackingInfo,  "trackingInfo") { it.optEncodeJson() ?: JSONObject.NULL }
+        putProp(this@encodeSharedJson, Block::conversion,  "conversion") { it.optEncodeJson() ?: JSONObject.NULL }
         putProp(this@encodeSharedJson, Block::tags) { JSONArray(it) }
     }
 }
@@ -626,7 +626,7 @@ internal fun ButtonBlock.Companion.decodeJson(json: JSONObject): ButtonBlock {
         keys = json.getJSONObject("keys").toStringHash(),
         text = Text.decodeJson(json.getJSONObject("text")),
         name = json.safeGetString("name"),
-        trackingInfo = TrackingInfo.optDecodeJson(json.optJSONObject("tracking")),
+        conversion = Conversion.optDecodeJson(json.optJSONObject("conversion")),
         tags = json.getJSONArray("tags").getStringIterable().toList()
     )
 }
@@ -649,10 +649,10 @@ internal fun Duration.Companion.decodeString(duration: String): Duration? =
     }
 
 
-internal fun TrackingInfo.Companion.optDecodeJson(json: JSONObject?): TrackingInfo? = when(json) {
+internal fun Conversion.Companion.optDecodeJson(json: JSONObject?): Conversion? = when(json) {
     null -> null
-    else -> TrackingInfo(
-        json.getString("key"),
+    else -> Conversion(
+        json.getString("tag"),
         Duration.decodeString(json.getString("expires"))!!
     )
 }
@@ -668,7 +668,7 @@ internal fun RectangleBlock.Companion.decodeJson(json: JSONObject): RectangleBlo
         position = Position.decodeJson(json.getJSONObject("position")),
         keys = json.getJSONObject("keys").toStringHash(),
         name = json.safeGetString("name"),
-        trackingInfo = TrackingInfo.optDecodeJson(json.optJSONObject("tracking")),
+        conversion = Conversion.optDecodeJson(json.optJSONObject("conversion")),
         tags = json.getJSONArray("tags").getStringIterable().toList()
     )
 }
@@ -685,7 +685,7 @@ internal fun WebViewBlock.Companion.decodeJson(json: JSONObject): WebViewBlock {
         keys = json.getJSONObject("keys").toStringHash(),
         webView = WebView.decodeJson(json.getJSONObject("webView")),
         name = json.safeGetString("name"),
-        trackingInfo = TrackingInfo.optDecodeJson(json.optJSONObject("tracking")),
+        conversion = Conversion.optDecodeJson(json.optJSONObject("conversion")),
         tags = json.getJSONArray("tags").getStringIterable().toList()
     )
 }
@@ -709,7 +709,7 @@ internal fun TextBlock.Companion.decodeJson(json: JSONObject): TextBlock {
         keys = json.getJSONObject("keys").toStringHash(),
         text = Text.decodeJson(json.getJSONObject("text")),
         name = json.safeGetString("name"),
-        trackingInfo = TrackingInfo.optDecodeJson(json.optJSONObject("tracking")),
+        conversion = Conversion.optDecodeJson(json.optJSONObject("conversion")),
         tags = json.getJSONArray("tags").getStringIterable().toList()
     )
 }
@@ -726,7 +726,7 @@ internal fun ImageBlock.Companion.decodeJson(json: JSONObject): ImageBlock {
         keys = json.getJSONObject("keys").toStringHash(),
         image = Image.optDecodeJSON(json.optJSONObject("image")),
         name = json.safeGetString("name"),
-        trackingInfo = TrackingInfo.optDecodeJson(json.optJSONObject("tracking")),
+        conversion = Conversion.optDecodeJson(json.optJSONObject("conversion")),
         tags = json.getJSONArray("tags").getStringIterable().toList()
     )
 }
@@ -773,7 +773,7 @@ fun ImagePollBlock.Companion.decodeJson(json: JSONObject): ImagePollBlock {
         tapBehavior = Block.TapBehavior.decodeJson(json.optJSONObject("tapBehavior")),
         border = Border.decodeJson(json.getJSONObject("border")),
         name = json.safeGetString("name"),
-        trackingInfo = TrackingInfo.optDecodeJson(json.optJSONObject("tracking")),
+        conversion = Conversion.optDecodeJson(json.optJSONObject("conversion")),
         tags = json.getJSONArray("tags").getStringIterable().toList(),
         imagePoll = ImagePoll.decodeJson(json.getJSONObject("imagePoll"))
     )
@@ -815,7 +815,7 @@ fun TextPollBlock.Companion.decodeJson(json: JSONObject): TextPollBlock {
         tapBehavior = Block.TapBehavior.decodeJson(json.optJSONObject("tapBehavior")),
         border = Border.decodeJson(json.getJSONObject("border")),
         name = json.safeGetString("name"),
-        trackingInfo = TrackingInfo.optDecodeJson(json.optJSONObject("tracking")),
+        conversion = Conversion.optDecodeJson(json.optJSONObject("conversion")),
         tags = json.getJSONArray("tags").getStringIterable().toList(),
         textPoll = TextPoll.decodeJson(json.getJSONObject("textPoll"))
     )
@@ -927,7 +927,7 @@ internal fun Screen.Companion.decodeJson(json: JSONObject): Screen {
         titleBar = TitleBar.decodeJson(json.getJSONObject("titleBar")),
         keys = json.getJSONObject("keys").toStringHash(),
         name = json.safeGetString("name"),
-        trackingInfo = TrackingInfo.optDecodeJson(json.optJSONObject("tracking")),
+        conversion = Conversion.optDecodeJson(json.optJSONObject("conversion")),
         tags = json.getJSONArray("tags").getStringIterable().toList()
     )
 }
@@ -942,7 +942,7 @@ internal fun Screen.encodeJson(): JSONObject {
         putProp(this@encodeJson, Screen::titleBar, "titleBar") { it.encodeJson() }
         putProp(this@encodeJson, Screen::keys) { JSONObject(it) }
         putProp(this@encodeJson, Screen::tags) { JSONArray(it) }
-        putProp(this@encodeJson, Screen::trackingInfo, "trackingInfo" ) { it.optEncodeJson() ?: JSONObject.NULL }
+        putProp(this@encodeJson, Screen::conversion, "conversion" ) { it.optEncodeJson() ?: JSONObject.NULL }
         putProp(this@encodeJson, Screen::name) { it }
     }
 }


### PR DESCRIPTION
Adds tracking info to blocks. This info object can be later used to track extra meta data in campaigns by adding expiring tags