### PR TITLE
Feature/468 - Poll Answered & App Opened Events

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
@@ -31,6 +31,7 @@ import io.rover.sdk.data.domain.TextPollBlock
 import io.rover.sdk.data.domain.WebView
 import io.rover.sdk.data.domain.WebViewBlock
 import io.rover.sdk.data.events.AnalyticsService
+import io.rover.sdk.data.events.AppOpenedTracker
 import io.rover.sdk.data.graphql.GraphQlApiService
 import io.rover.sdk.data.http.HttpClient
 import io.rover.sdk.logging.log
@@ -170,6 +171,8 @@ open class Rover(
         accountToken,
         eventEmitter
     )
+
+    private val appOpenedTracker: AppOpenedTracker = AppOpenedTracker(application, eventEmitter)
 
     private val pollsEndpoint = "https://polls.rover.io/v1/polls"
 

--- a/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/Rover.kt
@@ -172,7 +172,7 @@ open class Rover(
         eventEmitter
     )
 
-    private val appOpenedTracker: AppOpenedTracker = AppOpenedTracker(application, eventEmitter)
+    private val appOpenedTracker: AppOpenedTracker = AppOpenedTracker(eventEmitter)
 
     private val pollsEndpoint = "https://polls.rover.io/v1/polls"
 

--- a/sdk/src/main/kotlin/io/rover/sdk/data/events/AnalyticsService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/events/AnalyticsService.kt
@@ -69,7 +69,7 @@ internal class AnalyticsService(
             is RoverEvent.ScreenDismissed -> "Screen Dismissed" to eventInformation.toFlat()
             is RoverEvent.ScreenViewed -> "Screen Viewed" to eventInformation.toFlat()
             is RoverEvent.BlockTapped -> "Block Tapped" to eventInformation.toFlat()
-            else -> throw RuntimeException("Event not supported")
+            is RoverEvent.PollAnswered -> "Poll Answered" to eventInformation.toFlat()
         }
 
         return JSONObject().apply {
@@ -95,7 +95,7 @@ internal class AnalyticsService(
      * Initiates the [AnalyticsService] sending of analytics events.
      */
     init {
-        eventEmitter.trackedEvents.filter { it !is RoverEvent.PollAnswered }.subscribe { sendRequest(it) }
+        eventEmitter.trackedEvents.subscribe { sendRequest(it) }
     }
 
     private fun request(
@@ -140,6 +140,9 @@ private const val SCREEN_TAGS = "screenTags"
 private const val BLOCK_ID = "blockID"
 private const val BLOCK_NAME = "blockName"
 private const val BLOCK_TAGS = "blockTags"
+private const val OPTION_ID = "optionID"
+private const val OPTION_TEXT = "optionText"
+private const val OPTION_IMAGE = "optionImage"
 
 private fun RoverEvent.ExperiencePresented.toFlat(): Attributes {
     return hashMapOf(
@@ -212,4 +215,24 @@ private fun RoverEvent.BlockTapped.toFlat(): Attributes {
         BLOCK_NAME to block.name,
         BLOCK_TAGS to block.tags
     ) + if (campaignId != null) hashMapOf(CAMPAIGN_ID to campaignId) else hashMapOf()
+}
+
+private fun RoverEvent.PollAnswered.toFlat(): Attributes {
+    val attributes = mutableMapOf(
+        EXPERIENCE_ID to experience.id,
+        EXPERIENCE_NAME to experience.name,
+        EXPERIENCE_TAGS to experience.tags,
+        SCREEN_NAME to screen.name,
+        SCREEN_ID to screen.id,
+        SCREEN_TAGS to screen.tags,
+        BLOCK_ID to block.id,
+        BLOCK_NAME to block.name,
+        BLOCK_TAGS to block.tags,
+        OPTION_ID to option.id,
+        OPTION_TEXT to option.text
+    )
+    option.image?.let { attributes[OPTION_IMAGE] = it }
+    campaignId?.let { attributes[CAMPAIGN_ID] = it }
+
+    return attributes
 }

--- a/sdk/src/main/kotlin/io/rover/sdk/data/events/AnalyticsService.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/events/AnalyticsService.kt
@@ -13,11 +13,9 @@ import io.rover.sdk.platform.dateAsIso8601
 import io.rover.sdk.platform.debugExplanation
 import io.rover.sdk.platform.setRoverUserAgent
 import io.rover.sdk.services.EventEmitter
-import io.rover.sdk.streams.filter
 import io.rover.sdk.streams.subscribe
 import org.json.JSONObject
 import java.io.DataOutputStream
-import java.lang.RuntimeException
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.Date
@@ -70,13 +68,14 @@ internal class AnalyticsService(
             is RoverEvent.ScreenViewed -> "Screen Viewed" to eventInformation.toFlat()
             is RoverEvent.BlockTapped -> "Block Tapped" to eventInformation.toFlat()
             is RoverEvent.PollAnswered -> "Poll Answered" to eventInformation.toFlat()
+            is RoverEvent.AppOpened -> "App Opened" to mapOf()
         }
 
         return JSONObject().apply {
             put("anonymousID", installationIdentifier)
             put("event", eventName)
             put("timestamp", Date().dateAsIso8601())
-            put("properties", flatEvent.encodeJson())
+            if (flatEvent.isNotEmpty()) put("properties", flatEvent.encodeJson())
         }.toString()
     }
 

--- a/sdk/src/main/kotlin/io/rover/sdk/data/events/AppOpenedTracker.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/events/AppOpenedTracker.kt
@@ -1,35 +1,20 @@
 package io.rover.sdk.data.events
 
-import android.app.Activity
-import android.app.Application
-import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.ProcessLifecycleOwner
 import io.rover.sdk.services.EventEmitter
 
-internal class AppOpenedTracker(application: Application, private val eventEmitter: EventEmitter) {
-    var runningActivities = 0
-
+internal class AppOpenedTracker(private val eventEmitter: EventEmitter) {
     init {
-        application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
-            override fun onActivityCreated(activity: Activity?, savedInstanceState: Bundle?) { activityCreated() }
-            override fun onActivityStarted(activity: Activity?) {}
-            override fun onActivityResumed(activity: Activity?) {}
-            override fun onActivityPaused(activity: Activity?) {}
-            override fun onActivityStopped(activity: Activity?) {}
-            override fun onActivitySaveInstanceState(activity: Activity?, outState: Bundle?) {}
-            override fun onActivityDestroyed(activity: Activity?) { activityDestroyed() }
+        ProcessLifecycleOwner.get().lifecycle.addObserver(object : LifecycleObserver {
+            @OnLifecycleEvent(Lifecycle.Event.ON_START)
+            fun onStart() { trackAppOpenedEvent() }
         })
-    }
-
-    fun activityCreated() {
-        runningActivities =+ 1
-        if (runningActivities == 1) trackAppOpenedEvent()
     }
 
     private fun trackAppOpenedEvent() {
         eventEmitter.trackEvent(RoverEvent.AppOpened())
-    }
-
-    fun activityDestroyed() {
-        runningActivities =- 1
     }
 }

--- a/sdk/src/main/kotlin/io/rover/sdk/data/events/AppOpenedTracker.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/events/AppOpenedTracker.kt
@@ -1,0 +1,35 @@
+package io.rover.sdk.data.events
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import io.rover.sdk.services.EventEmitter
+
+internal class AppOpenedTracker(application: Application, private val eventEmitter: EventEmitter) {
+    var runningActivities = 0
+
+    init {
+        application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityCreated(activity: Activity?, savedInstanceState: Bundle?) { activityCreated() }
+            override fun onActivityStarted(activity: Activity?) {}
+            override fun onActivityResumed(activity: Activity?) {}
+            override fun onActivityPaused(activity: Activity?) {}
+            override fun onActivityStopped(activity: Activity?) {}
+            override fun onActivitySaveInstanceState(activity: Activity?, outState: Bundle?) {}
+            override fun onActivityDestroyed(activity: Activity?) { activityDestroyed() }
+        })
+    }
+
+    fun activityCreated() {
+        runningActivities =+ 1
+        if (runningActivities == 1) trackAppOpenedEvent()
+    }
+
+    private fun trackAppOpenedEvent() {
+        eventEmitter.trackEvent(RoverEvent.AppOpened())
+    }
+
+    fun activityDestroyed() {
+        runningActivities =- 1
+    }
+}

--- a/sdk/src/main/kotlin/io/rover/sdk/data/events/RoverEvent.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/events/RoverEvent.kt
@@ -46,6 +46,18 @@ sealed class RoverEvent {
         }
     }
 
+    class AppOpened() : RoverEvent() {
+        override fun encodeJson(): JSONObject {
+            return JSONObject().apply {
+                putOpt(ANALYTICS_EVENT_TYPE, POLL_ANSWERED_CODE)
+            }
+        }
+
+        internal companion object {
+            fun decodeJson(): AppOpened = AppOpened()
+        }
+    }
+
     data class PollAnswered(
         val experience: Experience,
         val screen: Screen,
@@ -238,6 +250,7 @@ sealed class RoverEvent {
         private const val EXPERIENCE_VIEWED_CODE = "EXPERIENCE VIEWED"
         private const val SCREEN_VIEWED_CODE = "SCREEN VIEWED"
         private const val SCREEN_PRESENTED_CODE = "SCREEN PRESENTED"
+        private const val APP_OPENED_CODE = "APP OPENED"
         private const val ANALYTICS_EVENT_TYPE = "ANALYTICS_EVENT_TYPE"
 
         fun decodeJson(jsonObject: JSONObject): RoverEvent {
@@ -260,6 +273,7 @@ sealed class RoverEvent {
                 SCREEN_VIEWED_CODE -> {
                     ScreenViewed.decodeJson(jsonObject)
                 }
+                APP_OPENED_CODE -> AppOpened.decodeJson()
                 else -> {
                     ScreenPresented.decodeJson(jsonObject)
                 }


### PR DESCRIPTION
## Description
Send Poll Answered and App Opened Events to analytics.rover.io.
App Opened Events are tracked whenever the App is foregrounded, specifically when the first activity `onStart` is called.

closes #468 