### PR TITLE
Use optDecoding for isDecorative for Image

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/data/operations/data/Experience.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/data/operations/data/Experience.kt
@@ -112,7 +112,7 @@ internal fun Image.Companion.optDecodeJSON(json: JSONObject?): Image? = when (js
         size = json.getInt("size"),
         url = json.safeGetUri("url"),
         accessibilityLabel = json.safeOptString("accessibilityLabel"),
-        isDecorative = json.getBoolean("isDecorative")
+        isDecorative = json.optBoolean("isDecorative")
     )
 }
 
@@ -124,7 +124,7 @@ internal fun Image.Companion.decodeJson(json: JSONObject): Image {
         size = json.getInt("size"),
         url = json.safeGetUri("url"),
         accessibilityLabel = json.safeOptString("accessibilityLabel"),
-        isDecorative = json.getBoolean("isDecorative")
+        isDecorative = json.optBoolean("isDecorative")
     )
 }
 


### PR DESCRIPTION
### Description
It seems as though it's possible for `isDecorative` to not be present in the json after testing so defaulting to false instead of throwing `JSONException`