### PR TITLE
Avoid border crash on empty size blocks

### DIFF
--- a/example-app/src/main/res/values/constants.xml
+++ b/example-app/src/main/res/values/constants.xml
@@ -1,6 +1,6 @@
 <!-- You'll set these fields during the Installation and Initialization steps of the documentation.-->
 <resources>
-    <string name="rover_api_token">72daccff7a7d497de0de3a8d3757dba99f8131e1</string>
+    <string name="rover_api_token">blank</string>
     <string name="uri_scheme">example</string>
     <string name="associated_domain">blank</string>
 </resources>

--- a/sdk/src/main/kotlin/io/rover/sdk/services/SessionTracker.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/services/SessionTracker.kt
@@ -63,7 +63,8 @@ internal class SessionTracker(
                 timerCallback()
             } else {
                 timerHandler.postDelayed(
-                    this::timerCallback, soonestExpiry * 1000L
+                    this::timerCallback,
+                    soonestExpiry * 1000L
                 )
             }
         }
@@ -137,7 +138,8 @@ internal class SessionStore(
         if (existingEntry != null) {
             // there is indeed a session open for the given key, mark it as expiring.
             setEntry(
-                sessionKey, existingEntry.copy(
+                sessionKey,
+                existingEntry.copy(
                     closedAt = Date()
                 )
             )
@@ -174,7 +176,7 @@ internal class SessionStore(
             .map { expiryTimeMsEpoch ->
                 ((expiryTimeMsEpoch - Date().time) / 1000).toInt()
             }
-            .min()
+            .minOrNull()
 
         // if there's a negative number, return 0 because there's already expired entries that need
         // to be dealt with now.

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/border/ViewBorder.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/concerns/border/ViewBorder.kt
@@ -125,7 +125,7 @@ internal class ViewBorder(
                 null
             }
 
-            val maskBitmap = if (viewModel.borderRadius != 0) {
+            val maskBitmap = if (viewModel.borderRadius != 0 && width > 0 && height > 0) {
                 val clipRect = RectF(
                     0f,
                     0f,

--- a/sdk/src/main/kotlin/io/rover/sdk/ui/containers/RoverActivity.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/containers/RoverActivity.kt
@@ -1,6 +1,7 @@
 package io.rover.sdk.ui.containers
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -47,7 +48,11 @@ open class RoverActivity : AppCompatActivity() {
      */
     protected open fun openUri(uri: Uri) {
         val intent = Intent(Intent.ACTION_VIEW, uri)
-        this.startActivity(intent)
+        try {
+            this.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            log.w("Could not open URI $uri because no Activity was found to handle it.")
+        }
     }
 
     /**


### PR DESCRIPTION
Avoids a crash in ViewBorder because an empty mask is not permitted by Android.

Slip in a couple riders:
* do not crash if unhandled URI in a block tap action. Replaced the dropped patch https://github.com/RoverPlatform/rover-android/pull/473 (that patch, on the now-retired develop branch, takes an approach that does not work on recent android and can cause some universal links to fail.
* resolve a regression introduced in previous (not shipped) PR: #478