### PR TITLE
Add editable device name property

### DIFF
--- a/core/src/main/kotlin/io/rover/sdk/core/events/contextproviders/DeviceIdentifierContextProvider.kt
+++ b/core/src/main/kotlin/io/rover/sdk/core/events/contextproviders/DeviceIdentifierContextProvider.kt
@@ -8,7 +8,7 @@ class DeviceIdentifierContextProvider(
     deviceIdentification: DeviceIdentificationInterface
 ) : ContextProvider {
     private val identifier = deviceIdentification.installationIdentifier
-    private val deviceName = deviceIdentification.deviceName
+    private var deviceName = deviceIdentification.deviceName
 
     override fun captureContext(deviceContext: DeviceContext): DeviceContext {
         return deviceContext.copy(

--- a/debug/src/main/kotlin/io/rover/sdk/debug/DebugPreferences.kt
+++ b/debug/src/main/kotlin/io/rover/sdk/debug/DebugPreferences.kt
@@ -40,7 +40,8 @@ class DebugPreferences(
                     title = context.getText(R.string.debug_settings_device_name)
                     summary = deviceIdentification.deviceName
                     key = "edit_device_name"
-                    dialogMessage = "Set the device name to be used for testing."
+                    dialogTitle = context.getText(R.string.debug_settings_set_device_id)
+                    dialogMessage = context.getText(R.string.debug_settings_device_id_description)
                     onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
                         deviceIdentification.deviceName = newValue as String
                         summary = newValue

--- a/debug/src/main/kotlin/io/rover/sdk/debug/DebugPreferences.kt
+++ b/debug/src/main/kotlin/io/rover/sdk/debug/DebugPreferences.kt
@@ -3,6 +3,7 @@ package io.rover.sdk.debug
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import androidx.preference.EditTextPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceManager
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
@@ -34,10 +35,17 @@ class DebugPreferences(
                 EditTextPreference(
                     preferenceManager.context
                 ).apply {
-                    isSelectable = false
+                    isSelectable = true
                     isPersistent = false
                     title = context.getText(R.string.debug_settings_device_name)
                     summary = deviceIdentification.deviceName
+                    key = "edit_device_name"
+                    dialogMessage = "Set the device name to be used for testing."
+                    onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+                        deviceIdentification.deviceName = newValue as String
+                        summary = newValue
+                        true
+                    }
                 }
             )
             addPreference(

--- a/debug/src/main/kotlin/io/rover/sdk/debug/DebugPreferences.kt
+++ b/debug/src/main/kotlin/io/rover/sdk/debug/DebugPreferences.kt
@@ -40,8 +40,8 @@ class DebugPreferences(
                     title = context.getText(R.string.debug_settings_device_name)
                     summary = deviceIdentification.deviceName
                     key = "edit_device_name"
-                    dialogTitle = context.getText(R.string.debug_settings_set_device_id)
-                    dialogMessage = context.getText(R.string.debug_settings_device_id_description)
+                    dialogTitle = context.getText(R.string.debug_settings_set_device_name)
+                    dialogMessage = context.getText(R.string.debug_settings_device_name_description)
                     onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
                         deviceIdentification.deviceName = newValue as String
                         summary = newValue

--- a/debug/src/main/res/values/strings.xml
+++ b/debug/src/main/res/values/strings.xml
@@ -4,6 +4,6 @@
     <string name="debug_settings_test_device">Test Device</string>
     <string name="debug_settings_device_name">Device Name</string>
     <string name="debug_settings_device_id">Device ID</string>
-    <string name="debug_settings_set_device_id">Set Device ID</string>
-    <string name="debug_settings_device_id_description">Set the device ID to be used for testing</string>
+    <string name="debug_settings_set_device_name">Set Device Name</string>
+    <string name="debug_settings_device_name_description">Set the device name to be used for testing</string>
 </resources>

--- a/debug/src/main/res/values/strings.xml
+++ b/debug/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="debug_settings_test_device">Test Device</string>
     <string name="debug_settings_device_name">Device Name</string>
     <string name="debug_settings_device_id">Device ID</string>
+    <string name="debug_settings_set_device_id">Set Device ID</string>
+    <string name="debug_settings_device_id_description">Set the device ID to be used for testing</string>
 </resources>


### PR DESCRIPTION
Make the device name property editable, while removing the dependency on the bluetooth name.  The fallback name is 'Phone' if the device name has never been set.

Resolves https://github.com/judoapp/rover-issues/issues/22