### PR TITLE
Backport image double tap fix

### DIFF
--- a/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/ViewImage.kt
+++ b/sdk/src/main/kotlin/io/rover/sdk/ui/blocks/image/ViewImage.kt
@@ -30,7 +30,10 @@ internal class ViewImage(
 
                 alpha = 0f
                 val isAccessible = binding.viewModel.isClickable || !binding.viewModel.isDecorative
-                isFocusableInTouchMode = isAccessible
+                // We do not want to set the image as focusable, because this causes undesirable
+                // behaviour for users not using TalkBack/a11y technology: they'd have to click
+                // the image twice if it has a click action on it.  importantForAccessibility
+                // is all we need to have the image be announced by TalkBack.
                 importantForAccessibility = if (isAccessible) {
                     contentDescription = binding.viewModel.accessibilityLabel
                     View.IMPORTANT_FOR_ACCESSIBILITY_YES


### PR DESCRIPTION
Image Blocks with tap behaviour had to be tapped twice (once to focus, once to activate) because they were incorrectly set as focusable in the accessbility support.

This is a backport of the same fix from Rover 4 https://github.com/RoverPlatform/rover-android-develop/pull/30